### PR TITLE
Add analytics reporting module

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,13 +19,19 @@ jobs:
         run: pip install rdflib pyshacl
       - name: Install service deps
         run: pip install fastapi "uvicorn[standard]" SPARQLWrapper
+      - name: Install analytics deps
+        run: pip install SPARQLWrapper
       - name: Lint
         run: |
           pip install flake8
           flake8 earCrawler/core/crawler.py earCrawler/service/sparql_service.py
+      - name: Lint analytics
+        run: python -m flake8 earCrawler/analytics
       - name: Run pytest
         run: pytest --maxfail=1 --disable-warnings
       - name: Run ingest tests
         run: python -m pytest tests/ingestion
       - name: Run service tests
         run: python -m pytest tests/service
+      - name: Run analytics tests
+        run: python -m pytest tests/analytics

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,4 @@
 - Add core crawler orchestration to fetch entities and documents for ingestion. [#VERSION]
 - Add ETL ingestion script with SHACL validation and Jena TDB2 loading. [#VERSION]
 - Add FastAPI-based SPARQL query service for TDB2 data. [#VERSION]
+- Add analytics ReportsGenerator module for SPARQL-based aggregate reporting. [#VERSION]

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ python -m venv .venv
 .\.venv\Scripts\activate
 python -m pip install -r requirements.txt
 cmdkey /generic:TRADEGOV_API_KEY /user:ignored /pass:<YOUR_API_KEY>
+REM Optional modules used by tests and examples
+python -m pip install rdflib pyshacl fastapi "uvicorn[standard]" SPARQLWrapper
 ```
 
 ## Repository Structure
@@ -98,6 +100,16 @@ from fastapi import FastAPI
 from earCrawler.service.sparql_service import app
 
 # run with: uvicorn earCrawler.service.sparql_service:app --reload
+```
+
+## Analytics
+```python
+from earCrawler.analytics.reports import ReportsGenerator
+
+reports = ReportsGenerator()
+print(reports.count_entities_by_country())
+print(reports.count_documents_by_year())
+print(reports.get_document_count_for_entity("ENTITY123"))
 ```
 
 

--- a/earCrawler/analytics/__init__.py
+++ b/earCrawler/analytics/__init__.py
@@ -1,0 +1,3 @@
+from .reports import ReportsGenerator, AnalyticsError
+
+__all__ = ["ReportsGenerator", "AnalyticsError"]

--- a/earCrawler/analytics/reports.py
+++ b/earCrawler/analytics/reports.py
@@ -1,0 +1,133 @@
+"""Analytics module providing aggregate SPARQL reports."""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from typing import Dict, List
+from urllib.error import HTTPError, URLError
+
+from SPARQLWrapper import SPARQLWrapper, JSON
+from SPARQLWrapper.SPARQLExceptions import QueryBadFormed
+
+
+class AnalyticsError(Exception):
+    """Raised when SPARQL analytics queries fail."""
+
+
+class ReportsGenerator:
+    """Generate aggregate reports against a SPARQL endpoint.
+
+    The endpoint URL is loaded from the ``SPARQL_ENDPOINT_URL`` environment
+    variable. All queries are predefined; callers cannot supply arbitrary
+    SPARQL to avoid injection risks.
+    """
+
+    def __init__(self) -> None:
+        endpoint = os.getenv("SPARQL_ENDPOINT_URL")
+        if not endpoint:
+            raise RuntimeError(
+                "SPARQL_ENDPOINT_URL environment variable not set"
+            )
+        self._wrapper = SPARQLWrapper(endpoint)
+        self._wrapper.setReturnFormat(JSON)
+        self.logger = logging.getLogger(__name__)
+
+        # Only run predefined SPARQL queries; do not accept raw queries from
+        # untrusted sources.
+        # Do not log or expose SPARQL_ENDPOINT_URL.
+    def _execute(self, query: str) -> List[dict]:
+        """Execute ``query`` and return result bindings.
+
+        Retries transient HTTP errors up to two times using exponential
+        backoff. Any persistent failure raises :class:`AnalyticsError`.
+        """
+
+        attempts = 3
+        delay = 1.0
+        for attempt in range(attempts):
+            try:
+                query_str = query.replace("\n", " ")[:200]
+                self.logger.info("Executing SPARQL query: %s", query_str)
+                self._wrapper.setQuery(query)
+                data = self._wrapper.query().convert()
+                bindings = data.get("results", {}).get("bindings", [])
+                self.logger.info("SPARQL returned %d rows", len(bindings))
+                return bindings
+            except HTTPError as exc:
+                code = getattr(exc, "code", 0)
+                if 500 <= code < 600 and attempt < attempts - 1:
+                    time.sleep(delay)
+                    delay *= 2
+                    continue
+                raise AnalyticsError(
+                    f"SPARQL endpoint error: {code}"
+                ) from exc
+            except URLError as exc:
+                if attempt < attempts - 1:
+                    time.sleep(delay)
+                    delay *= 2
+                    continue
+                raise AnalyticsError(
+                    f"SPARQL endpoint unreachable: {exc.reason}"
+                ) from exc
+            except QueryBadFormed as exc:  # pragma: no cover
+                raise AnalyticsError("Bad SPARQL query") from exc
+            except Exception as exc:  # pragma: no cover - unexpected errors
+                if attempt < attempts - 1:
+                    time.sleep(delay)
+                    delay *= 2
+                    continue
+                raise AnalyticsError(
+                    f"SPARQL query failed: {exc}"
+                ) from exc
+        raise AnalyticsError("SPARQL query failed after retries")
+
+    def count_entities_by_country(self) -> Dict[str, int]:
+        """Return a mapping of country codes to entity counts."""
+        query = (
+            "SELECT ?country (COUNT(?entity) AS ?count)\n"
+            "WHERE { ?entity <urn:prop:country> ?country }\n"
+            "GROUP BY ?country"
+        )
+        bindings = self._execute(query)
+        result: Dict[str, int] = {}
+        for b in bindings:
+            country = b.get("country", {}).get("value")
+            count = b.get("count", {}).get("value")
+            if country is not None and count is not None:
+                result[str(country)] = int(count)
+        return result
+
+    def count_documents_by_year(self) -> Dict[int, int]:
+        """Return document counts grouped by publication year."""
+        query = (
+            "SELECT ?year (COUNT(?doc) AS ?count)\n"
+            "WHERE { ?doc <urn:prop:year> ?year }\n"
+            "GROUP BY ?year"
+        )
+        bindings = self._execute(query)
+        result: Dict[int, int] = {}
+        for b in bindings:
+            year = b.get("year", {}).get("value")
+            count = b.get("count", {}).get("value")
+            if year is not None and count is not None:
+                result[int(year)] = int(count)
+        return result
+
+    def get_document_count_for_entity(self, entity_id: str) -> int:
+        """Return the number of documents linked to ``entity_id``."""
+        entity_id_escaped = entity_id.replace('"', '\\"')
+        query = (
+            "SELECT (COUNT(?doc) AS ?count)\n"
+            "WHERE {\n"
+            "  ?doc <urn:prop:entity> ?e .\n"
+            f'  FILTER (?e = "{entity_id_escaped}")\n'
+            "}"
+        )
+        bindings = self._execute(query)
+        if not bindings:
+            return 0
+        count = bindings[0].get("count", {}).get("value", "0")
+        return int(count)

--- a/tests/analytics/test_reports.py
+++ b/tests/analytics/test_reports.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+from pathlib import Path
+from urllib.error import HTTPError
+
+import pytest
+
+root = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(root))
+
+
+def _make_wrapper(responses):
+    class _Wrapper:
+        call_count = 0
+
+        def __init__(self, endpoint: str) -> None:
+            self.responses = list(responses)
+
+        def setReturnFormat(self, fmt):
+            self.fmt = fmt
+
+        def setQuery(self, q: str):
+            self.query_str = q
+
+        class _Result:
+            def __init__(self, data):
+                self.data = data
+
+            def convert(self):
+                return self.data
+
+        def query(self):
+            _Wrapper.call_count += 1
+            resp = self.responses.pop(0)
+            if isinstance(resp, Exception):
+                raise resp
+            return self._Result(resp)
+
+    return _Wrapper
+
+
+def _load_reports(monkeypatch, wrapper):
+    """Load the reports module with a stubbed SPARQLWrapper."""
+    monkeypatch.setenv("SPARQL_ENDPOINT_URL", "http://example.com")
+
+    # Provide a fake SPARQLWrapper module before importing the reports module
+    fake_module = types.ModuleType("SPARQLWrapper")
+    fake_module.SPARQLWrapper = wrapper
+    fake_module.JSON = object()
+    exceptions_mod = types.ModuleType("SPARQLWrapper.SPARQLExceptions")
+    exceptions_mod.QueryBadFormed = Exception
+    monkeypatch.setitem(sys.modules, "SPARQLWrapper", fake_module)
+    monkeypatch.setitem(
+        sys.modules,
+        "SPARQLWrapper.SPARQLExceptions",
+        exceptions_mod,
+    )
+
+    import earCrawler.analytics.reports as reports
+    importlib.reload(reports)
+    monkeypatch.setattr(reports.time, "sleep", lambda s: None)
+    return reports
+
+
+def test_count_entities_by_country(monkeypatch):
+    data = {
+        "results": {
+            "bindings": [
+                {"country": {"value": "US"}, "count": {"value": "2"}},
+                {"country": {"value": "CA"}, "count": {"value": "1"}},
+            ]
+        }
+    }
+    wrapper = _make_wrapper([data])
+    reports = _load_reports(monkeypatch, wrapper)
+    gen = reports.ReportsGenerator()
+    result = gen.count_entities_by_country()
+    assert result == {"US": 2, "CA": 1}
+    for k, v in result.items():
+        assert isinstance(k, str)
+        assert isinstance(v, int)
+
+
+def test_count_documents_by_year(monkeypatch):
+    data = {
+        "results": {
+            "bindings": [
+                {"year": {"value": "2023"}, "count": {"value": "5"}},
+                {"year": {"value": "2024"}, "count": {"value": "7"}},
+            ]
+        }
+    }
+    wrapper = _make_wrapper([data])
+    reports = _load_reports(monkeypatch, wrapper)
+    gen = reports.ReportsGenerator()
+    result = gen.count_documents_by_year()
+    assert result == {2023: 5, 2024: 7}
+    for k, v in result.items():
+        assert isinstance(k, int)
+        assert isinstance(v, int)
+
+
+def test_get_document_count_for_entity(monkeypatch):
+    data = {"results": {"bindings": [{"count": {"value": "4"}}]}}
+    wrapper = _make_wrapper([data])
+    reports = _load_reports(monkeypatch, wrapper)
+    gen = reports.ReportsGenerator()
+    count = gen.get_document_count_for_entity("E1")
+    assert count == 4
+    assert isinstance(count, int)
+
+
+def test_http_error_retry(monkeypatch):
+    err = HTTPError(None, 500, "boom", None, None)
+    wrapper = _make_wrapper([err, err, err])
+    reports = _load_reports(monkeypatch, wrapper)
+    gen = reports.ReportsGenerator()
+    with pytest.raises(reports.AnalyticsError):
+        gen.count_entities_by_country()
+    assert wrapper.call_count == 3


### PR DESCRIPTION
## Summary
- implement `ReportsGenerator` for SPARQL analytics
- add unit tests for analytics module
- integrate analytics lint/test steps in CI
- update README with analytics example and optional dependencies
- update changelog

## Testing
- `python -m flake8 earCrawler/analytics tests/analytics/test_reports.py`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a74295da48325a038f7b837fe0cac