### PR TITLE
Add analytics reports CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,12 +21,16 @@ jobs:
         run: pip install fastapi "uvicorn[standard]" SPARQLWrapper
       - name: Install analytics deps
         run: pip install SPARQLWrapper
+      - name: Install CLI deps
+        run: pip install click requests tabulate
       - name: Lint
         run: |
           pip install flake8
           flake8 earCrawler/core/crawler.py earCrawler/service/sparql_service.py
       - name: Lint analytics
         run: python -m flake8 earCrawler/analytics
+      - name: Lint CLI
+        run: python -m flake8 earCrawler/cli/reports_cli.py
       - name: Run pytest
         run: pytest --maxfail=1 --disable-warnings
       - name: Run ingest tests
@@ -35,3 +39,5 @@ jobs:
         run: python -m pytest tests/service
       - name: Run analytics tests
         run: python -m pytest tests/analytics
+      - name: Run CLI tests
+        run: python -m pytest tests/cli/test_reports_cli.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,3 +10,4 @@
 - Add ETL ingestion script with SHACL validation and Jena TDB2 loading. [#VERSION]
 - Add FastAPI-based SPARQL query service for TDB2 data. [#VERSION]
 - Add analytics ReportsGenerator module for SPARQL-based aggregate reporting. [#VERSION]
+- Add CLI for fetching analytics reports via FastAPI service. [#VERSION]

--- a/README.md
+++ b/README.md
@@ -112,6 +112,16 @@ print(reports.count_documents_by_year())
 print(reports.get_document_count_for_entity("ENTITY123"))
 ```
 
+## CLI
+```bash
+pip install .
+export ANALYTICS_SERVICE_URL=http://localhost:8000
+earCrawler reports entities-by-country
+earCrawler reports documents-by-year
+earCrawler reports document-count ENTITY123
+```
+
+
 
 ## Testing
 Run the test suite with:

--- a/earCrawler/cli/reports_cli.py
+++ b/earCrawler/cli/reports_cli.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+"""Command line interface for analytics reports."""
+
+import os
+from typing import Dict, Any
+
+import click
+import requests
+from tabulate import tabulate
+
+
+def _get_service_url() -> str:
+    """Return the analytics service base URL from ``ANALYTICS_SERVICE_URL``."""
+    url = os.getenv("ANALYTICS_SERVICE_URL")
+    if not url:
+        raise click.ClickException(
+            "ANALYTICS_SERVICE_URL environment variable not set"
+        )
+    return url.rstrip("/")
+
+
+@click.group()
+def reports() -> None:
+    """Fetch analytics reports from the FastAPI service."""
+
+
+@reports.command(name="entities-by-country")
+def entities_by_country() -> None:
+    """Display entity counts grouped by country."""
+    base_url = _get_service_url()
+    url = f"{base_url}/reports/entities-by-country"
+
+    try:
+        resp = requests.get(url, timeout=10)
+        resp.raise_for_status()
+    except requests.HTTPError as exc:
+        status = getattr(exc.response, "status_code", "")
+        click.echo(f"Request failed with status {status}", err=True)
+        raise SystemExit(1)
+    except requests.RequestException as exc:
+        click.echo(f"Request error: {exc}", err=True)
+        raise SystemExit(1)
+
+    try:
+        data = resp.json()
+    except ValueError:
+        click.echo("Malformed JSON response", err=True)
+        raise SystemExit(1)
+
+    mapping = data.get("entities_by_country")
+    if not isinstance(mapping, dict):
+        click.echo("Malformed response JSON", err=True)
+        raise SystemExit(1)
+
+    rows = sorted(mapping.items())
+    click.echo(tabulate(rows, headers=["Country", "Count"]))
+
+
+@reports.command(name="documents-by-year")
+def documents_by_year() -> None:
+    """Display document counts grouped by publication year."""
+    base_url = _get_service_url()
+    url = f"{base_url}/reports/documents-by-year"
+
+    try:
+        resp = requests.get(url, timeout=10)
+        resp.raise_for_status()
+    except requests.HTTPError as exc:
+        status = getattr(exc.response, "status_code", "")
+        click.echo(f"Request failed with status {status}", err=True)
+        raise SystemExit(1)
+    except requests.RequestException as exc:
+        click.echo(f"Request error: {exc}", err=True)
+        raise SystemExit(1)
+
+    try:
+        data = resp.json()
+    except ValueError:
+        click.echo("Malformed JSON response", err=True)
+        raise SystemExit(1)
+
+    mapping = data.get("documents_by_year")
+    if not isinstance(mapping, dict):
+        click.echo("Malformed response JSON", err=True)
+        raise SystemExit(1)
+
+    rows = sorted((str(k), v) for k, v in mapping.items())
+    click.echo(tabulate(rows, headers=["Year", "Count"]))
+
+
+@reports.command(name="document-count")
+@click.argument("entity_id")
+def document_count(entity_id: str) -> None:
+    """Display number of documents associated with ``ENTITY_ID``."""
+    if not entity_id or not entity_id.strip():
+        click.echo("entity_id must not be empty", err=True)
+        raise SystemExit(1)
+
+    base_url = _get_service_url()
+    url = f"{base_url}/reports/document-count/{entity_id}"
+
+    try:
+        resp = requests.get(url, timeout=10)
+        resp.raise_for_status()
+    except requests.HTTPError as exc:
+        status = getattr(exc.response, "status_code", "")
+        click.echo(f"Request failed with status {status}", err=True)
+        raise SystemExit(1)
+    except requests.RequestException as exc:
+        click.echo(f"Request error: {exc}", err=True)
+        raise SystemExit(1)
+
+    try:
+        data: Dict[str, Any] = resp.json()
+    except ValueError:
+        click.echo("Malformed JSON response", err=True)
+        raise SystemExit(1)
+
+    count = data.get("document_count")
+    if not isinstance(count, int):
+        click.echo("Malformed response JSON", err=True)
+        raise SystemExit(1)
+
+    click.echo(f"Entity {entity_id} has {count} documents")
+
+
+# Read service URL from env; do not hard-code.
+# Validate CLI args to prevent injection or misuse.
+# Do not log or expose sensitive URLs.
+if __name__ == "__main__":
+    reports()

--- a/tests/cli/test_reports_cli.py
+++ b/tests/cli/test_reports_cli.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+from typing import Any
+
+from click.testing import CliRunner
+
+root = Path(__file__).resolve().parents[2]  # noqa: E402
+import sys  # noqa: E402
+sys.path.insert(0, str(root))  # noqa: E402
+
+import earCrawler.cli.reports_cli as reports_cli  # noqa: E402
+
+
+def _reload() -> Any:
+    importlib.reload(reports_cli)
+    return reports_cli
+
+
+def test_entities_by_country_success(monkeypatch, requests_mock):
+    monkeypatch.setenv("ANALYTICS_SERVICE_URL", "http://example.com")
+    _reload()
+    requests_mock.get(
+        "http://example.com/reports/entities-by-country",
+        json={"entities_by_country": {"US": 2, "CA": 1}},
+    )
+    runner = CliRunner()
+    result = runner.invoke(reports_cli.reports, ["entities-by-country"])
+    assert result.exit_code == 0
+    assert "US" in result.output
+    assert "CA" in result.output
+
+
+def test_documents_by_year_success(monkeypatch, requests_mock):
+    monkeypatch.setenv("ANALYTICS_SERVICE_URL", "http://example.com")
+    _reload()
+    requests_mock.get(
+        "http://example.com/reports/documents-by-year",
+        json={"documents_by_year": {"2023": 5, "2024": 7}},
+    )
+    runner = CliRunner()
+    result = runner.invoke(reports_cli.reports, ["documents-by-year"])
+    assert result.exit_code == 0
+    assert "2023" in result.output
+    assert "7" in result.output
+
+
+def test_document_count_success(monkeypatch, requests_mock):
+    monkeypatch.setenv("ANALYTICS_SERVICE_URL", "http://example.com")
+    _reload()
+    requests_mock.get(
+        "http://example.com/reports/document-count/E1",
+        json={"entity_id": "E1", "document_count": 3},
+    )
+    runner = CliRunner()
+    result = runner.invoke(reports_cli.reports, ["document-count", "E1"])
+    assert result.exit_code == 0
+    assert "Entity E1 has 3 documents" in result.output
+
+
+def test_http_error(monkeypatch, requests_mock):
+    monkeypatch.setenv("ANALYTICS_SERVICE_URL", "http://example.com")
+    _reload()
+    requests_mock.get(
+        "http://example.com/reports/entities-by-country",
+        status_code=502,
+        text="bad",
+    )
+    runner = CliRunner()
+    result = runner.invoke(reports_cli.reports, ["entities-by-country"])
+    assert result.exit_code != 0
+    assert "502" in result.output
+
+
+def test_malformed_json(monkeypatch, requests_mock):
+    monkeypatch.setenv("ANALYTICS_SERVICE_URL", "http://example.com")
+    _reload()
+    requests_mock.get(
+        "http://example.com/reports/entities-by-country",
+        text="not json",
+    )
+    runner = CliRunner()
+    result = runner.invoke(reports_cli.reports, ["entities-by-country"])
+    assert result.exit_code != 0
+    assert "Malformed JSON" in result.output
+
+
+def test_timeout(monkeypatch):
+    monkeypatch.setenv("ANALYTICS_SERVICE_URL", "http://example.com")
+    _reload()
+
+    def raiser(*_a, **_kw):
+        raise reports_cli.requests.exceptions.Timeout("timeout")
+
+    monkeypatch.setattr(reports_cli.requests, "get", raiser)
+    runner = CliRunner()
+    result = runner.invoke(reports_cli.reports, ["documents-by-year"])
+    assert result.exit_code != 0
+    assert "timeout" in result.output
+
+
+def test_missing_env(monkeypatch):
+    monkeypatch.delenv("ANALYTICS_SERVICE_URL", raising=False)
+    _reload()
+    runner = CliRunner()
+    result = runner.invoke(reports_cli.reports, ["documents-by-year"])
+    assert result.exit_code != 0
+    assert "ANALYTICS_SERVICE_URL" in result.output
+
+
+def test_empty_entity_id(monkeypatch):
+    monkeypatch.setenv("ANALYTICS_SERVICE_URL", "http://example.com")
+    _reload()
+    runner = CliRunner()
+    result = runner.invoke(reports_cli.reports, ["document-count", " "])
+    assert result.exit_code != 0
+    assert "entity_id" in result.output


### PR DESCRIPTION
## Summary
- implement `earCrawler reports` CLI with click
- support country, year, and entity document count reports
- add CLI tests using requests-mock
- integrate CLI steps in CI workflow
- document usage in README and changelog

## Testing
- `python -m flake8 earCrawler/cli/reports_cli.py tests/cli/test_reports_cli.py`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a8632c78883258a211d30097550ad