### PR TITLE
Package earCrawler CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,3 +10,4 @@
 - Add ETL ingestion script with SHACL validation and Jena TDB2 loading. [#VERSION]
 - Add FastAPI-based SPARQL query service for TDB2 data. [#VERSION]
 - Add analytics ReportsGenerator module for SPARQL-based aggregate reporting. [#VERSION]
+- Package earCrawler as installable CLI with console-script entry-point (v0.1.0).

--- a/README.md
+++ b/README.md
@@ -27,6 +27,13 @@ REM Optional modules used by tests and examples
 python -m pip install rdflib pyshacl fastapi "uvicorn[standard]" SPARQLWrapper
 ```
 
+## Installation
+```powershell
+cd C:\Projects\earCrawler
+pip install .
+earCrawler --help
+```
+
 ## Repository Structure
 - `api_clients/` – clients for Trade.gov and Federal Register APIs.
 - `tests/` – unit tests covering success and failure scenarios.
@@ -110,6 +117,13 @@ reports = ReportsGenerator()
 print(reports.count_entities_by_country())
 print(reports.count_documents_by_year())
 print(reports.get_document_count_for_entity("ENTITY123"))
+```
+
+## CLI Usage
+```powershell
+earCrawler reports entities-by-country
+earCrawler reports documents-by-year
+earCrawler reports document-count ENTITY123
 ```
 
 

--- a/earCrawler/cli/__init__.py
+++ b/earCrawler/cli/__init__.py
@@ -1,0 +1,3 @@
+"""Command-line interfaces for earCrawler."""
+
+__all__ = ["reports_cli"]

--- a/earCrawler/cli/reports_cli.py
+++ b/earCrawler/cli/reports_cli.py
@@ -1,0 +1,51 @@
+"""CLI for EAR analytics reports."""
+
+from __future__ import annotations
+
+import click
+from tabulate import tabulate
+
+from earCrawler.analytics import ReportsGenerator
+
+
+@click.group()
+@click.version_option("0.1.0")
+def cli() -> None:
+    """Execute analytics reporting commands."""
+    pass
+
+
+@cli.command("entities-by-country")
+def entities_by_country() -> None:
+    """Display entity counts grouped by country."""
+    gen = ReportsGenerator()
+    data = gen.count_entities_by_country()
+    rows = sorted(data.items())
+    click.echo(tabulate(rows, headers=["Country", "Count"]))
+
+
+@cli.command("documents-by-year")
+def documents_by_year() -> None:
+    """Display document counts grouped by year."""
+    gen = ReportsGenerator()
+    data = gen.count_documents_by_year()
+    rows = sorted(data.items())
+    click.echo(tabulate(rows, headers=["Year", "Count"]))
+
+
+@cli.command("document-count")
+@click.argument("entity_id")
+def document_count(entity_id: str) -> None:
+    """Display document count for ``ENTITY_ID``."""
+    gen = ReportsGenerator()
+    count = gen.get_document_count_for_entity(entity_id)
+    click.echo(f"{entity_id}: {count}")
+
+
+def main() -> None:
+    """Entry point for the console script."""
+    cli()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,16 @@
+[project]
+name = "earCrawler"
+version = "0.1.0"
+description = "EAR AI ingestion, RAG, and analytics pipeline"
+authors = [{name="Your Name", email="you@example.com"}]
+license = { text = "MIT" }
+dependencies = [
+  "click>=8.0",
+  "requests>=2.31.0",
+  "fastapi>=0.85.0",
+  "SPARQLWrapper>=1.8.5",
+  "tabulate>=0.8.9"
+]
+
+[project.scripts]
+earCrawler = "earCrawler.cli.reports_cli:main"

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,23 @@
+from setuptools import setup, find_packages
+
+setup(
+    name="earCrawler",
+    version="0.1.0",
+    description="EAR AI ingestion, RAG, and analytics pipeline",
+    author="Your Name",
+    author_email="you@example.com",
+    packages=find_packages(),
+    install_requires=[
+        "click>=8.0",
+        "requests>=2.31.0",
+        "fastapi>=0.85.0",
+        "SPARQLWrapper>=1.8.5",
+        "tabulate>=0.8.9",
+    ],
+    entry_points={
+        "console_scripts": [
+            "earCrawler=earCrawler.cli.reports_cli:main"
+        ],
+    },
+    license="MIT",
+)


### PR DESCRIPTION
## Summary
- create packaging files for `earCrawler`
- implement a new CLI under `earCrawler.cli`
- document install/usage instructions
- note the packaging in CHANGELOG

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a884d1d14832594ce79baa0d0730b