### PR TITLE
Add FAISS-based RAG retriever

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,12 +23,16 @@ jobs:
         run: pip install SPARQLWrapper
       - name: Install CLI deps
         run: pip install click requests tabulate
+      - name: Install RAG deps
+        run: pip install sentence-transformers faiss-cpu
       - name: Lint
         run: |
           pip install flake8
           flake8 earCrawler/core/crawler.py earCrawler/service/sparql_service.py
       - name: Lint analytics
         run: python -m flake8 earCrawler/analytics
+      - name: Lint RAG code
+        run: python -m flake8 earCrawler/rag
       - name: Lint CLI
         run: python -m flake8 earCrawler/cli/reports_cli.py
       - name: Run pytest
@@ -39,5 +43,7 @@ jobs:
         run: python -m pytest tests/service
       - name: Run analytics tests
         run: python -m pytest tests/analytics
+      - name: Run RAG tests
+        run: python -m pytest tests/rag
       - name: Run CLI tests
         run: python -m pytest tests/cli/test_reports_cli.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,3 +12,4 @@
 - Add analytics ReportsGenerator module for SPARQL-based aggregate reporting. [#VERSION]
 - Add CLI for fetching analytics reports via FastAPI service. [#VERSION]
 - Package earCrawler as installable CLI with console-script entry-point (v0.1.0).
+- Implement RAG Retriever using all-MiniLM-L12-v2 and FAISS. [#VERSION]

--- a/README.md
+++ b/README.md
@@ -94,6 +94,22 @@ ingestor = Ingestor(
 )
 ingestor.run("emerging technology")
 ```
+## RAG
+```python
+from pathlib import Path
+from earCrawler.rag.retriever import Retriever
+from earCrawler.api_clients.tradegov_client import TradeGovClient
+from earCrawler.api_clients.federalregister_client import FederalRegisterClient
+
+retriever = Retriever(
+    TradeGovClient(),
+    FederalRegisterClient(),
+    model_name="all-MiniLM-L12-v2",
+    index_path=Path(r"C:\\Projects\\earCrawler\\data\\faiss\\index.faiss")
+)
+retriever.add_documents(docs)
+results = retriever.query("export control regulations", k=5)
+```
 ## Service
 ```python
 from fastapi import FastAPI

--- a/earCrawler/rag/retriever.py
+++ b/earCrawler/rag/retriever.py
@@ -1,0 +1,165 @@
+"""Lightweight RAG retriever built on FAISS and SentenceTransformers."""
+
+from __future__ import annotations
+
+# Load API keys from Windows Credential Store—never hard-code.
+# Secure your FAISS index path and model files.
+
+import logging
+import pickle
+import time
+from pathlib import WindowsPath
+from typing import List
+
+import faiss
+import numpy as np
+from sentence_transformers import SentenceTransformer
+
+from api_clients.tradegov_client import TradeGovClient
+from api_clients.federalregister_client import FederalRegisterClient
+
+
+class Retriever:
+    """Vector search over EAR documents using FAISS.
+
+    Parameters
+    ----------
+    tradegov_client:
+        Instance of :class:`TradeGovClient` used for future expansions.
+    fedreg_client:
+        Instance of :class:`FederalRegisterClient` used for future expansions.
+    model_name:
+        SentenceTransformer model name.
+    index_path:
+        Location of the FAISS index file.
+
+    Notes
+    -----
+    Load API keys from Windows Credential Store—never hard-code.
+    Secure your FAISS index path and model files.
+    """
+
+    def __init__(
+        self,
+        tradegov_client: TradeGovClient,
+        fedreg_client: FederalRegisterClient,
+        model_name: str = "all-MiniLM-L12-v2",
+        index_path: WindowsPath = WindowsPath(
+            r"C:\Projects\earCrawler\data\faiss\index.faiss"
+        ),
+    ) -> None:
+        self.tradegov_client = tradegov_client
+        self.fedreg_client = fedreg_client
+        self.model = SentenceTransformer(model_name)
+        self.index_path = WindowsPath(index_path)
+        self.meta_path = self.index_path.with_suffix(".pkl")
+        self.logger = logging.getLogger(__name__)
+
+    # ------------------------------------------------------------------
+    def _retry(self, func, *args, **kwargs):
+        attempts = 3
+        delay = 1.0
+        for attempt in range(attempts):
+            try:
+                return func(*args, **kwargs)
+            except Exception as exc:  # pragma: no cover - unexpected
+                if attempt < attempts - 1:
+                    self.logger.warning("Operation failed: %s; retrying", exc)
+                    time.sleep(delay)
+                    delay *= 2
+                    continue
+                self.logger.error("Operation failed after retries: %s", exc)
+                raise
+
+    # ------------------------------------------------------------------
+    def _load_index(self, dim: int) -> faiss.IndexIDMap:
+        if self.index_path.exists():
+            index = faiss.read_index(str(self.index_path))
+            if not isinstance(index, faiss.IndexIDMap):  # pragma: no cover
+                index = faiss.IndexIDMap(index)
+            return index
+        base = faiss.IndexFlatL2(dim)
+        return faiss.IndexIDMap(base)
+
+    # ------------------------------------------------------------------
+    def _load_metadata(self) -> List[dict]:
+        if self.meta_path.exists():
+            with self.meta_path.open("rb") as fh:
+                return pickle.load(fh)
+        return []
+
+    # ------------------------------------------------------------------
+    def _save_index(
+        self,
+        index: faiss.IndexIDMap,
+        metadata: List[dict],
+    ) -> None:
+        faiss.write_index(index, str(self.index_path))
+        with self.meta_path.open("wb") as fh:
+            pickle.dump(metadata, fh)
+
+    # ------------------------------------------------------------------
+    def add_documents(self, docs: List[dict]) -> None:
+        """Add ``docs`` to the FAISS index.
+
+        Parameters
+        ----------
+        docs:
+            List of document dictionaries. Text is taken from ``text``,
+            ``body``, ``summary`` or ``title`` fields.
+        """
+        if not docs:
+            self.logger.info("No documents provided for indexing")
+            return
+
+        texts = []
+        for d in docs:
+            text = (
+                d.get("text")
+                or d.get("body")
+                or d.get("summary")
+                or d.get("title")
+                or ""
+            )
+            texts.append(str(text))
+
+        vectors = self._retry(
+            self.model.encode,
+            texts,
+            show_progress_bar=False,
+        )
+        vectors = np.asarray(vectors).astype("float32")
+        dim = vectors.shape[1]
+
+        index = self._load_index(dim)
+        metadata = self._load_metadata()
+        start_id = len(metadata)
+        ids = np.arange(start_id, start_id + len(vectors))
+        index.add_with_ids(vectors, ids)
+        metadata.extend(docs)
+
+        self._save_index(index, metadata)
+        self.logger.info("Indexed %d documents", len(docs))
+
+    # ------------------------------------------------------------------
+    def query(self, prompt: str, k: int = 5) -> List[dict]:
+        """Return top ``k`` documents matching ``prompt``."""
+        if not self.index_path.exists():
+            self.logger.warning("Index file %s not found", self.index_path)
+            return []
+        embedding = self._retry(
+            self.model.encode,
+            [prompt],
+            show_progress_bar=False,
+        )
+        vector = np.asarray(embedding).astype("float32")
+        dim = vector.shape[1]
+
+        index = self._load_index(dim)
+        metadata = self._load_metadata()
+        distances, indices = index.search(vector, k)
+        results: List[dict] = []
+        for idx in indices[0]:
+            if 0 <= idx < len(metadata):
+                results.append(metadata[idx])
+        return results

--- a/tests/rag/test_retriever.py
+++ b/tests/rag/test_retriever.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+root = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(root))
+
+import importlib  # noqa: E402
+import pickle  # noqa: E402
+from types import SimpleNamespace  # noqa: E402
+import numpy as np  # noqa: E402
+
+
+class DummyModel:
+    def __init__(self, _name: str) -> None:
+        self.calls: list[list[str]] = []
+        self.fail_once = False
+
+    def encode(self, texts, show_progress_bar=False):
+        self.calls.append(list(texts))
+        if self.fail_once:
+            self.fail_once = False
+            raise RuntimeError("boom")
+        return np.ones((len(texts), 3), dtype="float32")
+
+
+class StubIndex:
+    def __init__(self) -> None:
+        self.added = []
+        self.ids = []
+        self.returns = (
+            np.zeros((1, 5), dtype="float32"),
+            np.array([[0, 1, -1, -1, -1]], dtype="int64"),
+        )
+
+    def add_with_ids(self, vecs, ids):
+        self.added.append(np.array(vecs))
+        self.ids.append(np.array(ids))
+
+    def search(self, vec, k):
+        return self.returns
+
+
+class IndexIDMapStub(StubIndex):
+    """Simple stand-in for faiss.IndexIDMap."""
+
+    def __new__(cls, base):
+        base.__class__ = cls
+        return base
+
+    def __init__(self, *_a, **_kw):  # noqa: D401
+        """No-op constructor."""
+
+
+class StubFaiss(SimpleNamespace):
+    IndexIDMap = IndexIDMapStub
+
+    def __init__(self, index: StubIndex) -> None:
+        super().__init__()
+        self.index = index
+        self.write_args = None
+
+    def IndexFlatL2(self, dim):  # noqa: N802 - mimics faiss API
+        self.dim = dim
+        return object()
+
+    # IndexIDMap class is callable; index returned via __new__
+
+    def read_index(self, path):  # noqa: N802
+        return self.index
+
+    def write_index(self, index, path):  # noqa: N802
+        self.write_args = (index, path)
+        Path(path).touch()
+
+
+def _load_retriever(monkeypatch, tmp_path, fail_encode=False):
+    index = StubIndex()
+    faiss_mod = StubFaiss(index)
+    monkeypatch.setitem(sys.modules, 'faiss', faiss_mod)
+    st_mod = SimpleNamespace(SentenceTransformer=lambda name: DummyModel(name))
+    monkeypatch.setitem(sys.modules, 'sentence_transformers', st_mod)
+    tg_mod = SimpleNamespace(TradeGovClient=object)
+    fr_mod = SimpleNamespace(FederalRegisterClient=object)
+    pkg_mod = SimpleNamespace(
+        TradeGovClient=object,
+        TradeGovError=Exception,
+        FederalRegisterClient=object,
+        FederalRegisterError=Exception,
+    )
+    monkeypatch.setitem(sys.modules, 'api_clients.tradegov_client', tg_mod)
+    monkeypatch.setitem(
+        sys.modules,
+        'api_clients.federalregister_client',
+        fr_mod,
+    )
+    monkeypatch.setitem(sys.modules, 'api_clients', pkg_mod)
+    import pathlib
+    monkeypatch.setattr(pathlib, 'WindowsPath', Path, raising=False)
+    import earCrawler.rag.retriever as retriever
+    importlib.reload(retriever)
+    monkeypatch.setattr(
+        retriever.Retriever,
+        '_load_index',
+        lambda self, dim: index,
+    )
+    model = DummyModel('x')
+    model.fail_once = fail_encode
+    monkeypatch.setattr(retriever, 'SentenceTransformer', lambda name: model)
+    monkeypatch.setattr(retriever, 'faiss', faiss_mod)
+    r = retriever.Retriever(
+        SimpleNamespace(),
+        SimpleNamespace(),
+        index_path=Path(tmp_path / 'idx.faiss'),
+    )
+    return r, model, index, faiss_mod
+
+
+def test_add_documents_creates_index(monkeypatch, tmp_path):
+    r, model, index, faiss_mod = _load_retriever(monkeypatch, tmp_path)
+    docs = [{'text': 'a'}, {'text': 'b'}]
+    r.add_documents(docs)
+    assert len(index.added[0]) == 2
+    assert faiss_mod.write_args[1] == str(r.index_path)
+    meta = pickle.load(open(r.meta_path, 'rb'))
+    assert meta == docs
+
+
+def test_add_documents_empty(monkeypatch, tmp_path):
+    r, _m, index, faiss_mod = _load_retriever(monkeypatch, tmp_path)
+    r.add_documents([])
+    assert index.added == []
+    assert not r.index_path.exists()
+
+
+def test_query_returns_docs(monkeypatch, tmp_path):
+    r, model, index, faiss_mod = _load_retriever(monkeypatch, tmp_path)
+    docs = [{'text': 'a'}, {'text': 'b'}]
+    r.add_documents(docs)
+    result = r.query('hi', k=2)
+    assert result == docs[:2]
+
+
+def test_query_no_index(monkeypatch, tmp_path):
+    r, _m, index, _f = _load_retriever(monkeypatch, tmp_path)
+    result = r.query('hi')
+    assert result == []
+
+
+def test_retry_on_encode_failure(monkeypatch, tmp_path):
+    r, model, index, _f = _load_retriever(
+        monkeypatch,
+        tmp_path,
+        fail_encode=True,
+    )
+    docs = [{'text': 'a'}]
+    r.add_documents(docs)
+    # encode should be called twice due to retry
+    assert len(model.calls) == 2


### PR DESCRIPTION
## Summary
- implement Retriever class leveraging FAISS and SentenceTransformers
- add unit tests for RAG Retriever
- integrate RAG linting and tests with CI
- document retriever usage in README
- record retriever addition in CHANGELOG

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688b95d71a208325a1419d369c90c6e7