### PR TITLE
Clarify retriever dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,12 @@ ingestor = Ingestor(
 ingestor.run("emerging technology")
 ```
 ## RAG
+To use the Retriever you must install the optional packages
+`sentence-transformers` and `faiss-cpu`:
+
+```bash
+pip install sentence-transformers faiss-cpu
+```
 ```python
 from pathlib import Path
 from earCrawler.rag.retriever import Retriever


### PR DESCRIPTION
## Summary
- document required packages for using `Retriever`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688baaaf96708325957dabc7bf933ac9