### PR TITLE
Add KG FastAPI service with validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
         run: pip install rdflib pyshacl
       - name: Install service deps
         run: pip install fastapi "uvicorn[standard]" SPARQLWrapper
+      - name: Install KG service deps
+        run: pip install fastapi SPARQLWrapper pyshacl
       - name: Install analytics deps
         run: pip install SPARQLWrapper
       - name: Install CLI deps
@@ -29,6 +31,8 @@ jobs:
         run: |
           pip install flake8
           flake8 earCrawler/core/crawler.py earCrawler/service/sparql_service.py
+      - name: Lint KG service
+        run: python -m flake8 earCrawler/service/kg_service.py
       - name: Lint analytics
         run: python -m flake8 earCrawler/analytics
       - name: Lint RAG code
@@ -41,6 +45,8 @@ jobs:
         run: python -m pytest tests/ingestion
       - name: Run service tests
         run: python -m pytest tests/service
+      - name: Run KG service tests
+        run: python -m pytest tests/service/test_kg_service.py
       - name: Run analytics tests
         run: python -m pytest tests/analytics
       - name: Run RAG tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,3 +13,4 @@
 - Add CLI for fetching analytics reports via FastAPI service. [#VERSION]
 - Package earCrawler as installable CLI with console-script entry-point (v0.1.0).
 - Implement RAG Retriever using all-MiniLM-L12-v2 and FAISS. [#VERSION]
+- Add FastAPI KG service with safe SPARQL query and SHACL-validated inserts. [#VERSION]

--- a/README.md
+++ b/README.md
@@ -124,6 +124,26 @@ from earCrawler.service.sparql_service import app
 # run with: uvicorn earCrawler.service.sparql_service:app --reload
 ```
 
+## Knowledge Graph Service
+Use the KG service to run safe SPARQL queries and insert validated triples.
+
+```bash
+curl -X POST http://localhost:8000/kg/query -H "Content-Type: application/json" \
+  -d "{\"sparql\": \"SELECT * WHERE {?s ?p ?o} LIMIT 1\"}"
+
+curl -X POST http://localhost:8000/kg/insert -H "Content-Type: application/json" \
+  -d "{\"ttl\": \"<a> <b> <c>.\"}"
+```
+
+```python
+from fastapi.testclient import TestClient
+from earCrawler.service.kg_service import app
+
+client = TestClient(app)
+resp = client.post("/kg/query", json={"sparql": "SELECT * WHERE {}"})
+print(resp.json())
+```
+
 ## Analytics
 ```python
 from earCrawler.analytics.reports import ReportsGenerator

--- a/earCrawler/service/kg_service.py
+++ b/earCrawler/service/kg_service.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+"""FastAPI Knowledge Graph service for SPARQL queries and inserts."""
+
+import logging
+import os
+from pathlib import Path
+from typing import Any, List
+
+from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel
+from SPARQLWrapper import SPARQLWrapper, JSON, POST
+from SPARQLWrapper.SPARQLExceptions import QueryBadFormed
+from urllib.error import HTTPError, URLError
+from rdflib import Graph
+from pyshacl import validate
+
+logger = logging.getLogger(__name__)
+
+# Load SPARQL_ENDPOINT_URL & SHAPES_FILE_PATH from env or credential store.
+ENDPOINT_URL = os.getenv("SPARQL_ENDPOINT_URL")
+SHAPES_PATH = os.getenv("SHAPES_FILE_PATH")
+if not ENDPOINT_URL:
+    raise RuntimeError("SPARQL_ENDPOINT_URL environment variable not set")
+if not SHAPES_PATH:
+    raise RuntimeError("SHAPES_FILE_PATH environment variable not set")
+
+app = FastAPI(title="Knowledge Graph Service")
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
+class QueryRequest(BaseModel):
+    """Input model for SPARQL SELECT queries."""
+
+    sparql: str
+
+
+class QueryResults(BaseModel):
+    """Output model for SPARQL query results."""
+
+    results: List[Any]
+
+
+class InsertRequest(BaseModel):
+    """Input model for inserting Turtle triples."""
+
+    ttl: str
+
+
+class InsertResponse(BaseModel):
+    """Output model after successful insert."""
+
+    inserted: bool
+
+
+@app.post("/kg/query", response_model=QueryResults)
+def run_query(payload: QueryRequest) -> QueryResults:
+    """Execute a safe SPARQL SELECT query against the endpoint."""
+    sparql = payload.sparql
+    logger.info("/kg/query: %s", sparql.replace("\n", " ")[:200])
+
+    if not sparql.strip().upper().startswith("SELECT"):
+        logger.error("Rejected non-SELECT query")
+        raise HTTPException(
+            status_code=400,
+            detail="Only SELECT queries are allowed",
+        )
+
+    wrapper = SPARQLWrapper(ENDPOINT_URL)
+    wrapper.setQuery(sparql)
+    wrapper.setReturnFormat(JSON)
+
+    try:
+        data = wrapper.query().convert()
+    except QueryBadFormed as exc:
+        logger.error("Bad SPARQL query: %s", exc)
+        raise HTTPException(
+            status_code=400,
+            detail="Invalid SPARQL query",
+        ) from exc
+    except (HTTPError, URLError) as exc:
+        logger.error("SPARQL endpoint error: %s", exc)
+        raise HTTPException(
+            status_code=502,
+            detail="SPARQL endpoint error",
+        ) from exc
+    except Exception as exc:  # pragma: no cover
+        logger.error("SPARQL request failed: %s", exc)
+        raise HTTPException(
+            status_code=502,
+            detail="SPARQL endpoint error",
+        ) from exc
+
+    bindings = data.get("results", {}).get("bindings", [])
+    return QueryResults(results=bindings)
+
+
+@app.post("/kg/insert", response_model=InsertResponse)
+def insert_triples(payload: InsertRequest) -> InsertResponse:
+    """Validate and insert TTL triples into the knowledge graph."""
+    ttl = payload.ttl
+    logger.info("/kg/insert received %d chars", len(ttl))
+
+    try:
+        data_graph = Graph().parse(data=ttl, format="turtle")
+    except Exception as exc:
+        logger.error("Turtle parse error: %s", exc)
+        raise HTTPException(
+            status_code=400,
+            detail="Invalid Turtle data",
+        ) from exc
+
+    shapes_path = Path(SHAPES_PATH).resolve()
+    try:
+        shapes_graph = Graph().parse(shapes_path)
+        conforms, _r, report = validate(
+            data_graph=data_graph,
+            shacl_graph=shapes_graph,
+            inference="rdfs",
+            serialize_report_graph=True,
+        )
+    except Exception as exc:
+        logger.error("SHACL validation error: %s", exc)
+        raise HTTPException(
+            status_code=400,
+            detail=str(exc),
+        ) from exc
+
+    if not conforms:
+        logger.error("SHACL validation failed: %s", report)
+        raise HTTPException(
+            status_code=400,
+            detail=str(report),
+        )
+
+    update_query = f"INSERT DATA {{\n{ttl}\n}}"
+    wrapper = SPARQLWrapper(ENDPOINT_URL)
+    wrapper.setMethod(POST)
+    wrapper.setQuery(update_query)
+
+    try:
+        wrapper.query()  # SPARQLWrapper returns a Response like object
+    except (HTTPError, URLError) as exc:
+        logger.error("SPARQL endpoint error: %s", exc)
+        raise HTTPException(
+            status_code=502,
+            detail="SPARQL endpoint error",
+        ) from exc
+    except Exception as exc:  # pragma: no cover
+        logger.error("SPARQL update failed: %s", exc)
+        raise HTTPException(
+            status_code=502,
+            detail="SPARQL endpoint error",
+        ) from exc
+
+    return InsertResponse(inserted=True)
+
+# Enforce operation whitelisting to prevent injection.

--- a/tests/rag/test_retriever.py
+++ b/tests/rag/test_retriever.py
@@ -112,7 +112,7 @@ def _load_retriever(monkeypatch, tmp_path, fail_encode=False):
     r = retriever.Retriever(
         SimpleNamespace(),
         SimpleNamespace(),
-        index_path=Path(tmp_path / 'idx.faiss'),
+        index_path=tmp_path / 'idx.faiss',
     )
     return r, model, index, faiss_mod
 

--- a/tests/service/test_kg_service.py
+++ b/tests/service/test_kg_service.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+from typing import Any
+from urllib.error import HTTPError
+
+from fastapi.testclient import TestClient
+
+root = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(root))
+
+
+class _Wrapper:
+    def __init__(self, endpoint: str) -> None:
+        self.queries: list[str] = []
+        self.method: Any | None = None
+        self.format: Any | None = None
+
+    def setQuery(self, q: str) -> None:  # noqa: N802
+        self.queries.append(q)
+
+    def setReturnFormat(self, fmt: Any) -> None:  # noqa: N802
+        self.format = fmt
+
+    def setMethod(self, method: Any) -> None:  # noqa: N802
+        self.method = method
+
+    class _Result:
+        def convert(self) -> dict:
+            return {"results": {"bindings": [{"x": {"value": "1"}}]}}
+
+    def query(self) -> "_Wrapper._Result":  # noqa: D401
+        return self._Result()
+
+
+class _HttpErrorWrapper(_Wrapper):
+    def query(self):  # noqa: D401,N802
+        raise HTTPError(None, 500, "boom", None, None)
+
+
+def _load_app(
+    monkeypatch,
+    wrapper_cls=_Wrapper,
+    validate_ret=(True, None, ""),
+    parse_ok=True,
+):
+    monkeypatch.setenv("SPARQL_ENDPOINT_URL", "http://example.com")
+    monkeypatch.setenv("SHAPES_FILE_PATH", "shapes.ttl")
+    import earCrawler.service.kg_service as svc
+    importlib.reload(svc)
+    monkeypatch.setattr(svc, "SPARQLWrapper", wrapper_cls)
+    monkeypatch.setattr(svc, "validate", lambda **_k: validate_ret)
+    if not parse_ok:
+        def bad_parse(self, *a, **k):
+            raise Exception("parse error")
+        monkeypatch.setattr(svc.Graph, "parse", bad_parse)
+    else:
+        monkeypatch.setattr(svc.Graph, "parse", lambda self, *a, **k: self)
+    return TestClient(svc.app)
+
+
+def test_query_success(monkeypatch):
+    client = _load_app(monkeypatch)
+    resp = client.post("/kg/query", json={"sparql": "SELECT * WHERE {}"})
+    assert resp.status_code == 200
+    assert resp.json() == {"results": [{"x": {"value": "1"}}]}
+
+
+def test_query_invalid(monkeypatch):
+    client = _load_app(monkeypatch)
+    resp = client.post("/kg/query", json={"sparql": "CONSTRUCT {}"})
+    assert resp.status_code == 400
+
+
+def test_query_http_error(monkeypatch):
+    client = _load_app(monkeypatch, wrapper_cls=_HttpErrorWrapper)
+    resp = client.post("/kg/query", json={"sparql": "SELECT * WHERE {}"})
+    assert resp.status_code == 502
+
+
+def test_insert_success(monkeypatch):
+    client = _load_app(monkeypatch)
+    ttl = "<a> <b> <c>."
+    resp = client.post("/kg/insert", json={"ttl": ttl})
+    assert resp.status_code == 200
+    assert resp.json() == {"inserted": True}
+
+
+def test_insert_shacl_failure(monkeypatch):
+    client = _load_app(monkeypatch, validate_ret=(False, None, "bad"))
+    resp = client.post("/kg/insert", json={"ttl": "<a> <b> <c>."})
+    assert resp.status_code == 400
+
+
+def test_insert_bad_ttl(monkeypatch):
+    client = _load_app(monkeypatch, parse_ok=False)
+    resp = client.post("/kg/insert", json={"ttl": "x"})
+    assert resp.status_code == 400
+
+
+def test_insert_http_error(monkeypatch):
+    client = _load_app(monkeypatch, wrapper_cls=_HttpErrorWrapper)
+    resp = client.post("/kg/insert", json={"ttl": "<a> <b> <c>."})
+    assert resp.status_code == 502


### PR DESCRIPTION
## Summary
- create a new FastAPI knowledge graph service with query and insert endpoints
- validate inserts using SHACL and route SELECT queries safely
- test KG service behaviours with monkeypatched SPARQLWrapper and pyshacl
- update CI workflow for linting and running KG service tests
- document KG service usage in README
- note new functionality in CHANGELOG
- fix incorrect Path re-instantiation in tests

## Testing
- `flake8 earCrawler/service/kg_service.py tests/service/test_kg_service.py`
- `flake8 tests/ingestion/test_ingest.py tests/rag/test_retriever.py`
- `pytest -q tests/service/test_kg_service.py` *(fails: ModuleNotFoundError: No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_688bafdcd6f883258ae6ab9ba8f26ced