### PR TITLE
refactor: use cross-platform paths

### DIFF
--- a/earCrawler/rag/retriever.py
+++ b/earCrawler/rag/retriever.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import logging
 import pickle
 import time
-from pathlib import WindowsPath
+from pathlib import Path
 from typing import List
 
 import faiss
@@ -44,14 +44,12 @@ class Retriever:
         tradegov_client: TradeGovClient,
         fedreg_client: FederalRegisterClient,
         model_name: str = "all-MiniLM-L12-v2",
-        index_path: WindowsPath = WindowsPath(
-            r"C:\Projects\earCrawler\data\faiss\index.faiss"
-        ),
+        index_path: Path = Path("data/faiss/index.faiss"),
     ) -> None:
         self.tradegov_client = tradegov_client
         self.fedreg_client = fedreg_client
         self.model = SentenceTransformer(model_name)
-        self.index_path = WindowsPath(index_path)
+        self.index_path = Path(index_path)
         self.meta_path = self.index_path.with_suffix(".pkl")
         self.logger = logging.getLogger(__name__)
 

--- a/tests/rag/test_retriever.py
+++ b/tests/rag/test_retriever.py
@@ -96,8 +96,6 @@ def _load_retriever(monkeypatch, tmp_path, fail_encode=False):
         fr_mod,
     )
     monkeypatch.setitem(sys.modules, 'api_clients', pkg_mod)
-    import pathlib
-    monkeypatch.setattr(pathlib, 'WindowsPath', Path, raising=False)
     import earCrawler.rag.retriever as retriever
     importlib.reload(retriever)
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary
- use cross-platform `Path` instead of Windows-specific `WindowsPath`
- drop unnecessary `WindowsPath` monkeypatch in tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f8be913dc83258e03d839950329e8