### PR TITLE
Add KG service with SHACL validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,10 +25,14 @@ jobs:
         run: pip install click requests tabulate
       - name: Install RAG deps
         run: pip install sentence-transformers faiss-cpu
+      - name: Install KG service deps
+        run: pip install fastapi SPARQLWrapper pyshacl
       - name: Lint
         run: |
           pip install flake8
           flake8 earCrawler/core/crawler.py earCrawler/service/sparql_service.py
+      - name: Lint KG service
+        run: python -m flake8 earCrawler/service/kg_service.py
       - name: Lint analytics
         run: python -m flake8 earCrawler/analytics
       - name: Lint RAG code
@@ -40,7 +44,9 @@ jobs:
       - name: Run ingest tests
         run: python -m pytest tests/ingestion
       - name: Run service tests
-        run: python -m pytest tests/service
+        run: python -m pytest tests/service/test_sparql_service.py
+      - name: Run KG service tests
+        run: python -m pytest tests/service/test_kg_service.py
       - name: Run analytics tests
         run: python -m pytest tests/analytics
       - name: Run RAG tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,3 +13,4 @@
 - Add CLI for fetching analytics reports via FastAPI service. [#VERSION]
 - Package earCrawler as installable CLI with console-script entry-point (v0.1.0).
 - Implement RAG Retriever using all-MiniLM-L12-v2 and FAISS. [#VERSION]
+- Add FastAPI KG service with safe SPARQL query and SHACL-validated inserts. [#VERSION]

--- a/README.md
+++ b/README.md
@@ -124,6 +124,34 @@ from earCrawler.service.sparql_service import app
 # run with: uvicorn earCrawler.service.sparql_service:app --reload
 ```
 
+## Knowledge Graph Service
+Start the service after setting environment variables for the SPARQL endpoint
+and SHACL shapes file:
+
+```cmd
+set SPARQL_ENDPOINT_URL=http://localhost:3030/ds
+set SHAPES_FILE_PATH=C:\path\to\shapes.ttl
+uvicorn earCrawler.service.kg_service:app --reload
+```
+
+Query the knowledge graph via ``curl``:
+
+```bash
+curl -X POST http://localhost:8000/kg/query \
+  -H "Content-Type: application/json" \
+  -d "{\"sparql\": \"SELECT * WHERE { ?s ?p ?o } LIMIT 1\"}"
+```
+
+Insert triples from Python:
+
+```python
+from fastapi.testclient import TestClient
+from earCrawler.service.kg_service import app
+
+client = TestClient(app)
+client.post("/kg/insert", json={"ttl": "<a> <b> <c> ."})
+```
+
 ## Analytics
 ```python
 from earCrawler.analytics.reports import ReportsGenerator

--- a/earCrawler/service/kg_service.py
+++ b/earCrawler/service/kg_service.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+"""FastAPI Knowledge Graph service for querying and inserting triples.
+
+This module exposes a minimal API in front of a SPARQL endpoint. It supports
+safe read-only ``SELECT`` queries and SHACL-validated inserts of Turtle
+triples.
+"""
+
+import logging
+import os
+from pathlib import Path
+from typing import Any, List
+
+from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel
+from SPARQLWrapper import JSON, SPARQLWrapper
+from SPARQLWrapper.SPARQLExceptions import QueryBadFormed
+from pyshacl import validate
+from urllib.error import HTTPError, URLError
+
+# Load SPARQL_ENDPOINT_URL & SHAPES_FILE_PATH from env or
+# Windows Credential Store.
+# Enforce operation whitelisting to prevent injection.
+ENDPOINT_URL = os.getenv("SPARQL_ENDPOINT_URL")
+SHAPES_FILE_PATH = os.getenv("SHAPES_FILE_PATH")
+if not ENDPOINT_URL or not SHAPES_FILE_PATH:
+    raise RuntimeError("SPARQL_ENDPOINT_URL and SHAPES_FILE_PATH must be set")
+
+SHAPES_PATH = Path(SHAPES_FILE_PATH)
+if not SHAPES_PATH.exists():
+    raise RuntimeError(f"SHAPES_FILE_PATH does not exist: {SHAPES_FILE_PATH}")
+
+SHAPES_TTL = SHAPES_PATH.read_text(encoding="utf-8")
+
+logger = logging.getLogger(__name__)
+
+app = FastAPI(title="Knowledge Graph Service")
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
+class QueryRequest(BaseModel):
+    """Request body for the ``/kg/query`` endpoint."""
+
+    sparql: str
+
+
+class QueryResponse(BaseModel):
+    """Response model for query results."""
+
+    results: List[Any]
+
+
+class InsertRequest(BaseModel):
+    """Request body for the ``/kg/insert`` endpoint."""
+
+    ttl: str
+
+
+class InsertResponse(BaseModel):
+    """Response model for triple insertion."""
+
+    inserted: bool
+
+
+@app.post("/kg/query", response_model=QueryResponse)
+def kg_query(body: QueryRequest) -> QueryResponse:
+    """Execute a read-only SPARQL ``SELECT`` query.
+
+    Parameters
+    ----------
+    body:
+        The request body containing a SPARQL ``SELECT`` statement.
+
+    Returns
+    -------
+    QueryResponse
+        JSON bindings under the ``results`` key.
+
+    Raises
+    ------
+    HTTPException
+        If the query is not a ``SELECT`` or the endpoint returns an error.
+    """
+
+    sparql = body.sparql
+    logger.info("Received KG query: %s", sparql.replace("\n", " ")[:200])
+
+    if not sparql.strip().upper().startswith("SELECT"):
+        logger.error("Rejected non-SELECT query")
+        raise HTTPException(
+            status_code=400,
+            detail="Only SELECT queries allowed",
+        )
+
+    wrapper = SPARQLWrapper(ENDPOINT_URL)
+    wrapper.setQuery(sparql)
+    wrapper.setReturnFormat(JSON)
+
+    try:
+        data = wrapper.query().convert()
+    except QueryBadFormed as exc:
+        logger.error("Bad SPARQL query: %s", exc)
+        raise HTTPException(
+            status_code=400,
+            detail="Invalid SPARQL query",
+        ) from exc
+    except (HTTPError, URLError) as exc:
+        logger.error("SPARQL endpoint error: %s", exc)
+        raise HTTPException(
+            status_code=502,
+            detail="SPARQL endpoint error",
+        ) from exc
+    except Exception as exc:  # pragma: no cover - unexpected
+        logger.error("SPARQL request failed: %s", exc)
+        raise HTTPException(
+            status_code=502,
+            detail="SPARQL endpoint error",
+        ) from exc
+
+    bindings = data.get("results", {}).get("bindings", [])
+    return QueryResponse(results=bindings)
+
+
+@app.post("/kg/insert", response_model=InsertResponse)
+def kg_insert(body: InsertRequest) -> InsertResponse:
+    """Validate and insert Turtle triples into the knowledge graph.
+
+    Parameters
+    ----------
+    body:
+        Request body containing Turtle triples to insert.
+
+    Returns
+    -------
+    InsertResponse
+        ``{"inserted": True}`` on success.
+
+    Raises
+    ------
+    HTTPException
+        If SHACL validation fails or the SPARQL endpoint returns an error.
+    """
+
+    ttl = body.ttl
+    logger.info("Received KG insert request")
+
+    try:
+        valid, _graph, text = validate(
+            data_graph=ttl,
+            shacl_graph=SHAPES_TTL,
+            data_graph_format="turtle",
+            shacl_graph_format="turtle",
+        )
+    except Exception as exc:  # pragma: no cover - pyshacl internal error
+        logger.error("SHACL validation error: %s", exc)
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    if not valid:
+        logger.error("SHACL validation failed: %s", text)
+        raise HTTPException(status_code=400, detail=text)
+
+    wrapper = SPARQLWrapper(ENDPOINT_URL)
+    wrapper.setMethod("POST")
+    wrapper.setQuery(f"INSERT DATA {{ {ttl} }}")
+
+    try:
+        wrapper.query()
+    except (HTTPError, URLError) as exc:
+        logger.error("SPARQL update error: %s", exc)
+        raise HTTPException(
+            status_code=502,
+            detail="SPARQL endpoint error",
+        ) from exc
+    except Exception as exc:  # pragma: no cover - unexpected
+        logger.error("SPARQL update failed: %s", exc)
+        raise HTTPException(
+            status_code=502,
+            detail="SPARQL endpoint error",
+        ) from exc
+
+    return InsertResponse(inserted=True)

--- a/tests/service/test_kg_service.py
+++ b/tests/service/test_kg_service.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import importlib
+from typing import Any
+from urllib.error import HTTPError
+
+from fastapi.testclient import TestClient
+
+
+class _GoodWrapper:
+    def __init__(self, endpoint: str) -> None:
+        self.query_str: str | None = None
+        self.method: str | None = None
+
+    def setQuery(self, q: str) -> None:  # noqa: N802 - external API
+        self.query_str = q
+
+    def setReturnFormat(self, fmt: Any) -> None:  # noqa: N802 - external API
+        self.format = fmt
+
+    def setMethod(self, method: str) -> None:  # noqa: N802 - external API
+        self.method = method
+
+    class _Result:
+        def convert(self) -> dict:
+            return {"results": {"bindings": [{"x": {"value": "1"}}]}}
+
+    def query(self):  # noqa: D401 - external API
+        return self._Result()
+
+
+class _HttpErrorWrapper(_GoodWrapper):
+    def query(self):  # noqa: D401,N802
+        raise HTTPError(None, 500, "boom", None, None)
+
+
+def _load_app(monkeypatch, wrapper_cls, validate_func, tmp_path) -> TestClient:
+    shapes_file = tmp_path / "shapes.ttl"
+    shapes_file.write_text("@prefix ex: <http://example.org/> .", encoding="utf-8")
+
+    monkeypatch.setenv("SPARQL_ENDPOINT_URL", "http://example.com")
+    monkeypatch.setenv("SHAPES_FILE_PATH", str(shapes_file))
+
+    import earCrawler.service.kg_service as svc
+    importlib.reload(svc)
+    monkeypatch.setattr(svc, "SPARQLWrapper", wrapper_cls)
+    monkeypatch.setattr(svc, "validate", validate_func)
+    return TestClient(svc.app)
+
+
+def test_query_success(monkeypatch, tmp_path):
+    client = _load_app(monkeypatch, _GoodWrapper, lambda **_: (True, None, ""), tmp_path)
+    resp = client.post("/kg/query", json={"sparql": "SELECT * WHERE {}"})
+    assert resp.status_code == 200
+    assert resp.json() == {"results": [{"x": {"value": "1"}}]}
+
+
+def test_query_invalid(monkeypatch, tmp_path):
+    client = _load_app(monkeypatch, _GoodWrapper, lambda **_: (True, None, ""), tmp_path)
+    resp = client.post("/kg/query", json={"sparql": "CONSTRUCT {}"})
+    assert resp.status_code == 400
+
+
+def test_query_http_error(monkeypatch, tmp_path):
+    client = _load_app(monkeypatch, _HttpErrorWrapper, lambda **_: (True, None, ""), tmp_path)
+    resp = client.post("/kg/query", json={"sparql": "SELECT * WHERE {}"})
+    assert resp.status_code == 502
+
+
+def test_insert_success(monkeypatch, tmp_path):
+    validate_ok = lambda **_: (True, None, "")
+    client = _load_app(monkeypatch, _GoodWrapper, validate_ok, tmp_path)
+    resp = client.post("/kg/insert", json={"ttl": "<a> <b> <c> ."})
+    assert resp.status_code == 200
+    assert resp.json() == {"inserted": True}
+
+
+def test_insert_validation_error(monkeypatch, tmp_path):
+    validate_bad = lambda **_: (False, None, "bad")
+    client = _load_app(monkeypatch, _GoodWrapper, validate_bad, tmp_path)
+    resp = client.post("/kg/insert", json={"ttl": "<a> <b> <c> ."})
+    assert resp.status_code == 400
+    assert "bad" in resp.text
+
+
+def test_insert_http_error(monkeypatch, tmp_path):
+    validate_ok = lambda **_: (True, None, "")
+    client = _load_app(monkeypatch, _HttpErrorWrapper, validate_ok, tmp_path)
+    resp = client.post("/kg/insert", json={"ttl": "<a> <b> <c> ."})
+    assert resp.status_code == 502


### PR DESCRIPTION
## Summary
- implement FastAPI knowledge graph service for safe SPARQL queries and SHACL-validated inserts
- document KG service usage and add changelog entry
- extend CI for KG service linting and tests

## Testing
- `python -m flake8 earCrawler/earCrawler/service/kg_service.py`
- `PYTHONPATH=earCrawler pytest earCrawler/tests/service/test_kg_service.py`

------
https://chatgpt.com/codex/tasks/task_e_68910102b9dc8325b3f8f9cfcb41ecb1