### PR TITLE
Add Docker deployment and monitoring

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches: ['**']
+    tags: ['v*']
+  pull_request:
 
 jobs:
   build-and-test:
@@ -63,3 +67,31 @@ jobs:
         run: pip install sentence-transformers faiss-cpu peft bitsandbytes
       - name: Run benchmark script
         run: python scripts/benchmark.py --queries scripts/benchmark_queries.json
+
+  release:
+    if: startsWith(github.ref, 'refs/tags/')
+    needs: build-and-test
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build API image
+        run: docker build -f docker/api.Dockerfile -t ghcr.io/${{ github.repository }}/api:${{ github.ref_name }} .
+      - name: Push API image
+        run: docker push ghcr.io/${{ github.repository }}/api:${{ github.ref_name }}
+      - name: Build RAG image
+        run: docker build -f docker/rag.Dockerfile -t ghcr.io/${{ github.repository }}/rag:${{ github.ref_name }} .
+      - name: Push RAG image
+        run: docker push ghcr.io/${{ github.repository }}/rag:${{ github.ref_name }}
+      - name: Build agent image
+        run: docker build -f docker/mistral.Dockerfile -t ghcr.io/${{ github.repository }}/agent:${{ github.ref_name }} .
+      - name: Push agent image
+        run: docker push ghcr.io/${{ github.repository }}/agent:${{ github.ref_name }}
+      - name: Run monitor against staging
+        shell: pwsh
+        run: ./monitor.ps1 -Services @('https://staging/api/health','https://staging/kg/health','https://staging/agent/health')

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,3 +17,4 @@
 - Add Legal-BERT fine-tuning using PEFT/LoRA adapters. [#VERSION]
 - Add Mistral-7B QLoRA instruction-tuned agent with LoRA adapters. [#VERSION]
 - Add end-to-end benchmark script integrating LoRA and QLoRA components. [#VERSION]
+- Finalize production Docker images and monitoring for LoRA/QLoRA pipeline. [#VERSION]

--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ REM Optional modules used by tests and examples
 python -m pip install rdflib pyshacl fastapi "uvicorn[standard]" SPARQLWrapper sentence-transformers faiss-cpu
 ```
 
+## Secret Management
+- Store API keys and SPARQL URLs in the Windows Credential Manager or as
+  environment variables. Never commit secrets to source control.
+- Rotate credentials with `cmdkey /delete:<NAME>` followed by a new `cmdkey`
+  command. See `RUNBOOK.md` for detailed procedures.
+
 ## Repository Structure
 - `api_clients/` – clients for Trade.gov and Federal Register APIs.
 - `tests/` – unit tests covering success and failure scenarios.

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1,0 +1,28 @@
+# Runbook
+
+## Deploying LoRA/QLoRA Models
+1. Tag a release: `git tag vX.Y.Z && git push origin vX.Y.Z`.
+2. GitHub Actions builds and pushes `api`, `rag`, and `agent` images to GHCR.
+3. On the host, pull images:
+   - `docker pull ghcr.io/<org>/earCrawler/api:vX.Y.Z`
+   - `docker pull ghcr.io/<org>/earCrawler/rag:vX.Y.Z`
+   - `docker pull ghcr.io/<org>/earCrawler/agent:vX.Y.Z`
+4. Mount adapter weights or model artifacts into the container under `models/`.
+5. Restart services with `docker compose up -d`.
+
+## Rollback
+1. Locate previous stable tag.
+2. Pull prior images using that tag.
+3. Redeploy containers with the older tag.
+4. Run `monitor.ps1` to verify `/health` endpoints report `ok`.
+
+## Secret Rotation
+- API keys and SPARQL URLs are stored in Windows Credential Manager or as environment variables.
+- Rotate a credential:
+  1. `cmdkey /delete:TRADEGOV_API_KEY`
+  2. `cmdkey /generic:TRADEGOV_API_KEY /user:ignored /pass:<NEW_VALUE>`
+- For environment variables, update deployment configuration and restart containers.
+
+## Monitoring
+Execute `./monitor.ps1 -Services @('http://localhost:8000/health')` to poll services.
+Failures are written to `monitor.log` and the Windows Event Log under source `EARMonitor`.

--- a/docker/api.Dockerfile
+++ b/docker/api.Dockerfile
@@ -1,0 +1,7 @@
+# syntax=docker/dockerfile:1
+FROM python:3.11-slim
+WORKDIR /app
+COPY . /app
+RUN pip install --no-cache-dir -r requirements.txt \
+    bitsandbytes peft sentence-transformers faiss-cpu
+CMD ["sh", "-c", "uvicorn ${APP_MODULE:-earCrawler.service.sparql_service:app} --host 0.0.0.0 --port 8000"]

--- a/docker/mistral.Dockerfile
+++ b/docker/mistral.Dockerfile
@@ -1,0 +1,7 @@
+# syntax=docker/dockerfile:1
+FROM python:3.11-slim
+WORKDIR /app
+COPY . /app
+RUN pip install --no-cache-dir -r requirements.txt \
+    bitsandbytes peft sentence-transformers faiss-cpu
+CMD ["python", "-m", "earCrawler.agent.mistral_agent"]

--- a/docker/rag.Dockerfile
+++ b/docker/rag.Dockerfile
@@ -1,0 +1,7 @@
+# syntax=docker/dockerfile:1
+FROM python:3.11-slim
+WORKDIR /app
+COPY . /app
+RUN pip install --no-cache-dir -r requirements.txt \
+    bitsandbytes peft sentence-transformers faiss-cpu
+CMD ["python", "-m", "earCrawler.rag.retriever"]

--- a/earCrawler/service/kg_service.py
+++ b/earCrawler/service/kg_service.py
@@ -20,10 +20,12 @@ from SPARQLWrapper.SPARQLExceptions import QueryBadFormed
 from pyshacl import validate
 from urllib.error import HTTPError, URLError
 
+from .utils import get_secret
+
 # Load SPARQL_ENDPOINT_URL & SHAPES_FILE_PATH from env or
 # Windows Credential Store.
 # Enforce operation whitelisting to prevent injection.
-ENDPOINT_URL = os.getenv("SPARQL_ENDPOINT_URL")
+ENDPOINT_URL = get_secret("SPARQL_ENDPOINT_URL")
 SHAPES_FILE_PATH = os.getenv("SHAPES_FILE_PATH")
 if not ENDPOINT_URL or not SHAPES_FILE_PATH:
     raise RuntimeError("SPARQL_ENDPOINT_URL and SHAPES_FILE_PATH must be set")
@@ -186,3 +188,9 @@ def kg_insert(body: InsertRequest) -> InsertResponse:
         ) from exc
 
     return InsertResponse(inserted=True)
+
+
+@app.get("/health")
+def health() -> dict[str, str]:
+    """Basic health check endpoint."""
+    return {"status": "ok"}

--- a/earCrawler/service/sparql_service.py
+++ b/earCrawler/service/sparql_service.py
@@ -3,21 +3,22 @@ from __future__ import annotations
 """FastAPI service for executing SPARQL SELECT queries."""
 
 import logging
-import os
 from typing import Any, List
 
 from fastapi import FastAPI, HTTPException, Query
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
-from SPARQLWrapper import SPARQLWrapper, JSON
+from SPARQLWrapper import JSON, SPARQLWrapper
 from SPARQLWrapper.SPARQLExceptions import QueryBadFormed
 from urllib.error import HTTPError, URLError
 
+from .utils import get_secret
+
 logger = logging.getLogger(__name__)
 
-ENDPOINT_URL = os.getenv("SPARQL_ENDPOINT_URL")
+ENDPOINT_URL = get_secret("SPARQL_ENDPOINT_URL")
 if not ENDPOINT_URL:
-    raise RuntimeError("SPARQL_ENDPOINT_URL environment variable not set")
+    raise RuntimeError("SPARQL_ENDPOINT_URL not configured")
 
 app = FastAPI(title="SPARQL Service")
 app.add_middleware(
@@ -78,3 +79,9 @@ def run_query(
 
     bindings = data.get("results", {}).get("bindings", [])
     return QueryResponse(results=bindings)
+
+
+@app.get("/health")
+def health() -> dict[str, str]:
+    """Basic health check endpoint."""
+    return {"status": "ok"}

--- a/earCrawler/service/utils.py
+++ b/earCrawler/service/utils.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import os
+
+try:  # pragma: no cover - optional on non-Windows
+    import win32cred  # type: ignore
+except Exception:  # pragma: no cover - fallback when unavailable
+    win32cred = None  # type: ignore
+
+
+def get_secret(name: str) -> str | None:
+    """Return secret ``name`` from env or Windows Credential Store."""
+    val = os.getenv(name)
+    if val:
+        return val
+    if win32cred is not None:  # pragma: no cover - platform specific
+        try:
+            cred = win32cred.CredRead(name, win32cred.CRED_TYPE_GENERIC, 0)
+            return cred["CredentialBlob"].decode("utf-16")
+        except Exception:
+            return None
+    return None

--- a/monitor.ps1
+++ b/monitor.ps1
@@ -1,0 +1,23 @@
+param(
+    [String[]]$Services = @("http://localhost:8000/health"),
+    [String]$LogPath = "monitor.log"
+)
+
+if (-not [System.Diagnostics.EventLog]::SourceExists("EARMonitor")) {
+    New-EventLog -LogName Application -Source "EARMonitor" | Out-Null
+}
+
+foreach ($url in $Services) {
+    try {
+        $resp = Invoke-RestMethod -Uri $url -Method Get -TimeoutSec 5
+        if ($resp.status -ne "ok") {
+            $msg = "Health check failed for $url"
+            Add-Content -Path $LogPath -Value "$(Get-Date -Format o) $msg"
+            Write-EventLog -LogName Application -Source "EARMonitor" -EntryType Error -EventId 1000 -Message $msg
+        }
+    } catch {
+        $msg = "Health check error for $url: $($_.Exception.Message)"
+        Add-Content -Path $LogPath -Value "$(Get-Date -Format o) $msg"
+        Write-EventLog -LogName Application -Source "EARMonitor" -EntryType Error -EventId 1001 -Message $msg
+    }
+}

--- a/tests/service/test_kg_service.py
+++ b/tests/service/test_kg_service.py
@@ -88,3 +88,10 @@ def test_insert_http_error(monkeypatch, tmp_path):
     client = _load_app(monkeypatch, _HttpErrorWrapper, validate_ok, tmp_path)
     resp = client.post("/kg/insert", json={"ttl": "<a> <b> <c> ."})
     assert resp.status_code == 502
+
+
+def test_health(monkeypatch, tmp_path):
+    client = _load_app(monkeypatch, _GoodWrapper, lambda **_: (True, None, ""), tmp_path)
+    resp = client.get("/health")
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ok"}

--- a/tests/service/test_sparql_service.py
+++ b/tests/service/test_sparql_service.py
@@ -67,3 +67,10 @@ def test_invalid_query(monkeypatch):
     client = _load_app(monkeypatch, _GoodWrapper)
     resp = client.get("/query", params={"sparql": "CONSTRUCT {}"})
     assert resp.status_code == 400
+
+
+def test_health(monkeypatch):
+    client = _load_app(monkeypatch, _GoodWrapper)
+    resp = client.get("/health")
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ok"}


### PR DESCRIPTION
## Summary
- containerize API services, retriever, and Mistral agent with images that include bitsandbytes, peft, sentence-transformers, and faiss-cpu
- add secret loader and `/health` checks to FastAPI services
- document deploy/rollback and secret rotation; add monitoring script and release workflow

## Testing
- `pip install -r requirements.txt sentence-transformers faiss-cpu`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689255d4e1b08325b016b2d690331871