### PR TITLE
chore: prepare release 0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,13 @@ a RAG (Retrieval Augmented Generation) approach.
 - **Trade.gov API key**
 - **Docker Desktop**
 
+## Installation
+Install earCrawler version 0.2.0 from PyPI:
+
+```bash
+pip install earCrawler==0.2.0
+```
+
 ## Setup
 Use the commands below from a Windows terminal. The repository is assumed to be
 cloned to `C:\Users\cfrydenlund\Projects\earCrawler`.

--- a/earCrawler/__init__.py
+++ b/earCrawler/__init__.py
@@ -1,2 +1,2 @@
 __all__ = ["__version__"]
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/requirements-gpu.txt
+++ b/requirements-gpu.txt
@@ -1,0 +1,15 @@
+requests==2.31.0
+pywin32==306; sys_platform == "win32"
+pytest==8.4.1
+requests-mock==1.11.0
+httpx==0.28.1
+click==8.2.1
+tabulate==0.9.0
+bitsandbytes==0.43.1
+peft==0.11.1
+transformers==4.39.3
+fastapi==0.116.1
+pyshacl==0.30.1
+SPARQLWrapper==2.0.0
+torch==2.3.0+cu118
+accelerate

--- a/requirements-win.txt
+++ b/requirements-win.txt
@@ -1,0 +1,1 @@
+-r requirements.txt


### PR DESCRIPTION
## Summary
- bump package version to 0.2.0
- document versioned installation instructions
- add Windows and GPU requirements split

## Testing
- `pytest`

Once CI passes, tag this commit as `v0.2.0`.

------
https://chatgpt.com/codex/tasks/task_e_68926631ce1483258ee1bbcb100df800