### PR TITLE
test: add gpu lora test and quant config test

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+markers =
+    gpu: tests requiring a GPU
+    cpu: tests that run on CPU only

--- a/tests/unit/test_lora_adapter.py
+++ b/tests/unit/test_lora_adapter.py
@@ -1,0 +1,39 @@
+import pytest
+import torch
+from transformers import AutoModelForCausalLM, AutoTokenizer
+from peft import LoraConfig, get_peft_model
+
+
+@pytest.mark.gpu
+def test_lora_adapter_merge_changes_logits():
+    """LoRA adapter merge should change model logits."""
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA required")
+    device = torch.device("cuda")
+    model = AutoModelForCausalLM.from_pretrained("sshleifer/tiny-gpt2").to(device)
+    tokenizer = AutoTokenizer.from_pretrained("sshleifer/tiny-gpt2")
+
+    inputs = tokenizer("Hello", return_tensors="pt").to(device)
+    with torch.no_grad():
+        base_logits = model(**inputs).logits
+
+    config = LoraConfig(
+        r=1,
+        lora_alpha=1,
+        lora_dropout=0.0,
+        bias="none",
+        target_modules=["c_attn"],
+        layers_to_transform=[0],
+    )
+    lora_model = get_peft_model(model, config)
+    # Make LoRA weights non-zero so merge has an effect
+    for name, param in lora_model.named_parameters():
+        if "lora_" in name:
+            param.data.fill_(0.5)
+
+    merged_model = lora_model.merge_and_unload()
+    with torch.no_grad():
+        merged_logits = merged_model(**inputs).logits
+
+    shift = (merged_logits - base_logits).abs().max().item()
+    assert shift != 0

--- a/tests/unit/test_quant_config.py
+++ b/tests/unit/test_quant_config.py
@@ -1,0 +1,23 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+root = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(root))
+
+quant_mod = pytest.importorskip("earCrawler.quant")
+
+
+def _get_config():
+    if hasattr(quant_mod, "QuantConfig"):
+        return quant_mod.QuantConfig(bits=4)
+    if hasattr(quant_mod, "get_quant_config"):
+        return quant_mod.get_quant_config(bits=4)
+    pytest.fail("Quantization config not found")
+
+
+def test_quant_config_4bit():
+    config = _get_config()
+    assert config.bits == 4
+    assert config.quant_type in ["nf4", "fp4"]


### PR DESCRIPTION
## Summary
- add GPU-marked test to ensure merging a dummy LoRA adapter changes GPT-2 logits
- add unit test for quantization config in `earCrawler.quant`
- register `gpu`/`cpu` markers in pytest config

## Testing
- `pytest tests/unit/test_lora_adapter.py -q`
- `pytest tests/unit/test_quant_config.py -q -rs`


------
https://chatgpt.com/codex/tasks/task_e_68938e938d8483258d3f695d731bc380