### PR TITLE
feat: unify corpus loaders and add crawl CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 - CLI ``nsf-parse`` command and ORI client scaffold.
 - Unit tests with offline HTML fixtures.
 - Documentation updates and Windows CI workflow running ``pytest``.
+- Unified ``CorpusLoader`` with EAR and NSF loaders and ``crawl`` CLI command.
+- Federal Register client no longer requires an API key.
+- Trade.gov client can read API key from environment variables.
 
 ## [0.2.0]
 ### Added

--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ for doc in client.search_documents("export controls", per_page=50):
     print(doc["document_number"])
 ```
 
+The Federal Register API is public and requires no API key.
+
 ## NSF Case Parser
 Parse NSF/ORI misconduct cases from offline HTML. The parser extracts
 paragraphs, entities, and a deterministic hash for each case. Use the CLI:
@@ -104,15 +106,22 @@ paragraphs, entities, and a deterministic hash for each case. Use the CLI:
 python -m earCrawler.cli nsf-parse --fixtures tests/fixtures --out data --live false
 ```
 
-Each case is written as a JSON file under `data`. Store Trade.gov and Federal
-Register API keys in the Windows Credential Manager:
+Each case is written as a JSON file under `data`. Store the Trade.gov API key in
+the Windows Credential Manager:
 
 ```cmd
 cmdkey /generic:TRADEGOV_API_KEY /user:ignored /pass:<YOUR_API_KEY>
-cmdkey /generic:FEDREGISTER_API_KEY /user:ignored /pass:<YOUR_API_KEY>
 ```
 
 An ORI client scaffold is included for future live crawling.
+
+## Unified Corpus Loader
+Use the ``CorpusLoader`` abstraction to consume paragraphs from different
+sources. The CLI can load multiple corpora at once:
+
+```cmd
+python -m earCrawler.cli crawl --sources ear nsf
+```
 
 ## Core
 Combine both clients using the ``Crawler`` orchestration layer:

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -37,3 +37,12 @@ python -m earCrawler.cli nsf-parse --fixtures tests/fixtures --out data --live f
 
 The command writes one JSON file per case into the `data` directory. Supply
 `--live` to fetch fresh listings when networking is permitted.
+
+## Unified Crawl
+Run the corpus loaders via the CLI:
+
+```cmd
+python -m earCrawler.cli crawl --sources ear nsf
+```
+
+Only the Trade.gov API key is required; the Federal Register API is public.

--- a/api_clients/__init__.py
+++ b/api_clients/__init__.py
@@ -5,8 +5,13 @@ when the optional dependencies are missing.
 """
 
 try:  # pragma: no cover - platform specific
-    from .tradegov_client import TradeGovClient, TradeGovError
+    from .tradegov_client import (
+        TradeGovEntityClient,
+        TradeGovClient,
+        TradeGovError,
+    )
 except Exception:  # pragma: no cover - optional on non-Windows
+    TradeGovEntityClient = None  # type: ignore
     TradeGovClient = None  # type: ignore
     TradeGovError = Exception  # type: ignore
 

--- a/earCrawler/core/corpus_loader.py
+++ b/earCrawler/core/corpus_loader.py
@@ -1,0 +1,18 @@
+"""Unified corpus loader abstraction."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Dict, Iterator, List
+
+
+class CorpusLoader(ABC):
+    """Abstract base class for paragraph loaders."""
+
+    @abstractmethod
+    def iterate_paragraphs(self) -> Iterator[Dict[str, object]]:
+        """Yield dictionaries with ``source``, ``text`` and ``identifier``."""
+
+    def load_paragraphs(self) -> List[Dict[str, object]]:
+        """Return all paragraphs as a list."""
+        return list(self.iterate_paragraphs())

--- a/earCrawler/core/ear_loader.py
+++ b/earCrawler/core/ear_loader.py
@@ -1,0 +1,34 @@
+"""EAR paragraph loader implementing :class:`CorpusLoader`."""
+
+from __future__ import annotations
+
+from typing import Dict, Iterator
+
+from bs4 import BeautifulSoup
+
+from api_clients.federalregister_client import FederalRegisterClient
+from .corpus_loader import CorpusLoader
+
+
+class EARLoader(CorpusLoader):
+    """Load paragraphs from the Federal Register EAR documents."""
+
+    def __init__(self, client: FederalRegisterClient, query: str) -> None:
+        self.client = client
+        self.query = query
+
+    def iterate_paragraphs(self) -> Iterator[Dict[str, object]]:
+        for doc in self.client.search_documents(self.query):
+            doc_number = str(doc.get("document_number", ""))
+            detail = self.client.get_document(doc_number)
+            html = detail.get("html", "")
+            soup = BeautifulSoup(html, "html.parser")
+            for idx, p in enumerate(soup.find_all("p")):
+                text = " ".join(p.get_text(" ").split())
+                if not text:
+                    continue
+                yield {
+                    "source": "ear",
+                    "text": text,
+                    "identifier": f"{doc_number}:{idx}",
+                }

--- a/earCrawler/core/nsf_case_parser.py
+++ b/earCrawler/core/nsf_case_parser.py
@@ -50,7 +50,7 @@ class NSFCaseParser:
 
     def paragraphs(self, html: str) -> List[str]:
         """Return normalized paragraphs with minimum length."""
-        soup = BeautifulSoup(html, "lxml")
+        soup = BeautifulSoup(html, "html.parser")
         paras: List[str] = []
         for p in soup.find_all("p"):
             text = self.normalize(p.get_text(" "))
@@ -60,7 +60,7 @@ class NSFCaseParser:
 
     def parse_from_html(self, html: str, url: str) -> Dict[str, object]:
         """Parse a case detail page HTML."""
-        soup = BeautifulSoup(html, "lxml")
+        soup = BeautifulSoup(html, "html.parser")
         title_tag = soup.find("h1")
         title = self.normalize(title_tag.get_text(" ")) if title_tag else ""
         match = re.search(r"Case Number\s*(\S+)", title)
@@ -88,7 +88,7 @@ class NSFCaseParser:
         if live:
             client = ORIClient()
             listing_html = client.get_listing_html()
-            listing = BeautifulSoup(listing_html, "lxml")
+            listing = BeautifulSoup(listing_html, "html.parser")
             links = [a["href"] for a in listing.select("a[href]")]
             for link in links:
                 url = link if link.startswith("http") else f"{client.BASE_URL}{link}"
@@ -97,7 +97,7 @@ class NSFCaseParser:
         else:
             fixtures_dir = Path(fixtures_dir)
             listing_html = (fixtures_dir / "ori_case_listing.html").read_text(encoding="utf-8")
-            listing = BeautifulSoup(listing_html, "lxml")
+            listing = BeautifulSoup(listing_html, "html.parser")
             links = [a["href"] for a in listing.select("a[href]")]
             for link in links:
                 case_path = fixtures_dir / link

--- a/earCrawler/core/nsf_loader.py
+++ b/earCrawler/core/nsf_loader.py
@@ -1,0 +1,28 @@
+"""NSF case paragraph loader implementing :class:`CorpusLoader`."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, Iterator
+
+from .corpus_loader import CorpusLoader
+from .nsf_case_parser import NSFCaseParser
+
+
+class NSFLoader(CorpusLoader):
+    """Load paragraphs from NSF/ORI case files."""
+
+    def __init__(self, parser: NSFCaseParser, fixtures_dir: Path) -> None:
+        self.parser = parser
+        self.fixtures_dir = fixtures_dir
+
+    def iterate_paragraphs(self) -> Iterator[Dict[str, object]]:
+        cases = self.parser.run(self.fixtures_dir, live=False)
+        for case in cases:
+            case_number = case.get("case_number", "")
+            for idx, para in enumerate(case.get("paragraphs", [])):
+                yield {
+                    "source": "nsf",
+                    "text": para,
+                    "identifier": f"{case_number}:{idx}",
+                }

--- a/tests/api_clients/test_federalregister_client.py
+++ b/tests/api_clients/test_federalregister_client.py
@@ -2,117 +2,40 @@ from __future__ import annotations
 
 import importlib
 import sys
-import types
 from pathlib import Path
 
 import pytest
 
 
-def _import_client(api_key: str | None):
-    module = types.SimpleNamespace()
-    module.CRED_TYPE_GENERIC = 1
-
-    def cred_read(name: str, cred_type: int, flags: int):
-        assert name == "FEDREGISTER_API_KEY"
-        if api_key is None:
-            raise Exception("missing")
-        return {"CredentialBlob": api_key.encode("utf-16")}
-
-    module.CredRead = cred_read
-    sys.modules["win32cred"] = module
+def _import_client():
     root = Path(__file__).resolve().parents[2]
     sys.path.insert(0, str(root))
-    fr = importlib.import_module("api_clients.federalregister_client")
-    importlib.reload(fr)
-    return fr
+    module = importlib.import_module("api_clients.federalregister_client")
+    importlib.reload(module)
+    return module
 
 
-def test_search_single_page(requests_mock):
-    fr = _import_client("secret")
-    resp = {"results": [{"id": 1}]}
+def test_search_documents_no_key(requests_mock):
+    fr = _import_client()
+    resp = {"results": [{"document_number": "1"}]}
     m = requests_mock.get(
         "https://api.federalregister.gov/v1/documents",
         json=resp,
     )
     client = fr.FederalRegisterClient()
     results = list(client.search_documents("foo"))
-    assert results == [{"id": 1}]
+    assert results == [{"document_number": "1"}]
     assert m.call_count == 1
+    assert "api_key" not in m.last_request.qs
 
 
-def test_search_multi_page(requests_mock):
-    fr = _import_client("secret")
-    responses = [
-        {"json": {"results": [{"id": 1}]}},
-        {"json": {"results": [{"id": 2}]}},
-        {"json": {"results": []}},
-    ]
+def test_get_document(requests_mock):
+    fr = _import_client()
     m = requests_mock.get(
-        "https://api.federalregister.gov/v1/documents",
-        responses,
+        "https://api.federalregister.gov/v1/documents/1",
+        json={"id": 1},
     )
     client = fr.FederalRegisterClient()
-    results = list(client.search_documents("foo", per_page=1))
-    assert results == [{"id": 1}, {"id": 2}]
-    assert m.call_count == 3
-
-
-def test_client_error(requests_mock):
-    fr = _import_client("secret")
-    requests_mock.get(
-        "https://api.federalregister.gov/v1/documents",
-        status_code=404,
-        text="missing",
-    )
-    client = fr.FederalRegisterClient()
-    with pytest.raises(fr.FederalRegisterError):
-        list(client.search_documents("foo"))
-
-
-def test_retries_on_server_error(requests_mock, monkeypatch):
-    fr = _import_client("secret")
-    responses = [
-        {"status_code": 500},
-        {"status_code": 502},
-        {"json": {"results": []}},
-    ]
-    m = requests_mock.get(
-        "https://api.federalregister.gov/v1/documents",
-        responses,
-    )
-    sleeps: list[float] = []
-    monkeypatch.setattr("time.sleep", lambda s: sleeps.append(s))
-    client = fr.FederalRegisterClient()
-    results = list(client.search_documents("foo"))
-    assert results == []
-    assert m.call_count == 3
-    assert sleeps == [1, 2]
-
-
-def test_empty_results(requests_mock):
-    fr = _import_client("secret")
-    requests_mock.get(
-        "https://api.federalregister.gov/v1/documents",
-        json={"results": []},
-    )
-    client = fr.FederalRegisterClient()
-    results = list(client.search_documents("foo"))
-    assert results == []
-
-
-def test_invalid_json(requests_mock):
-    fr = _import_client("secret")
-    requests_mock.get(
-        "https://api.federalregister.gov/v1/documents",
-        text="not json",
-        status_code=200,
-    )
-    client = fr.FederalRegisterClient()
-    with pytest.raises(fr.FederalRegisterError):
-        list(client.search_documents("foo"))
-
-
-def test_missing_api_key():
-    fr = _import_client(None)
-    with pytest.raises(RuntimeError):
-        fr.FederalRegisterClient()
+    result = client.get_document("1")
+    assert result == {"id": 1}
+    assert m.call_count == 1

--- a/tests/api_clients/test_tradegov_client.py
+++ b/tests/api_clients/test_tradegov_client.py
@@ -1,105 +1,101 @@
 from __future__ import annotations
 
 import importlib
+import os
 import sys
-import types
 from pathlib import Path
 
 import pytest
 
 
-def _import_client(api_key: str | None):
-    module = types.SimpleNamespace()
-    module.CRED_TYPE_GENERIC = 1
-
-    def cred_read(name: str, cred_type: int, flags: int):
-        assert name == "TRADEGOV_API_KEY"
-        if api_key is None:
-            raise Exception("missing")
-        return {"CredentialBlob": api_key.encode("utf-16")}
-
-    module.CredRead = cred_read
-    sys.modules["win32cred"] = module
+def _import_client():
     root = Path(__file__).resolve().parents[2]
     sys.path.insert(0, str(root))
-    tg = importlib.import_module("api_clients.tradegov_client")
-    importlib.reload(tg)
-    return tg
+    module = importlib.import_module("api_clients.tradegov_client")
+    importlib.reload(module)
+    return module
 
 
-def test_search_single_page(requests_mock):
-    tg = _import_client("secret")
+def test_search_single_page(requests_mock, monkeypatch):
+    monkeypatch.setenv("TRADEGOV_API_KEY", "secret")
+    tg = _import_client()
     resp = {"results": [{"id": 1}], "next_page": None}
     m = requests_mock.get("https://api.trade.gov/v1/entities/search", json=resp)
-    client = tg.TradeGovClient()
+    client = tg.TradeGovEntityClient()
     results = list(client.search_entities("foo"))
     assert results == [{"id": 1}]
     assert m.call_count == 1
 
 
-def test_search_multi_page(requests_mock):
-    tg = _import_client("secret")
+def test_search_multi_page(requests_mock, monkeypatch):
+    monkeypatch.setenv("TRADEGOV_API_KEY", "secret")
+    tg = _import_client()
     responses = [
         {"json": {"results": [{"id": 1}], "next_page": 2}},
         {"json": {"results": [{"id": 2}], "next_page": None}},
     ]
     m = requests_mock.get("https://api.trade.gov/v1/entities/search", responses)
-    client = tg.TradeGovClient()
+    client = tg.TradeGovEntityClient()
     results = list(client.search_entities("foo"))
     assert results == [{"id": 1}, {"id": 2}]
     assert m.call_count == 2
 
 
-def test_client_error(requests_mock):
-    tg = _import_client("secret")
+def test_client_error(requests_mock, monkeypatch):
+    monkeypatch.setenv("TRADEGOV_API_KEY", "secret")
+    tg = _import_client()
     requests_mock.get(
         "https://api.trade.gov/v1/entities/search",
         status_code=404,
         json={"error": "missing"},
     )
-    client = tg.TradeGovClient()
+    client = tg.TradeGovEntityClient()
     with pytest.raises(tg.TradeGovError):
         list(client.search_entities("foo"))
 
 
-def test_retries_on_server_error(requests_mock):
-    tg = _import_client("secret")
+def test_retries_on_server_error(requests_mock, monkeypatch):
+    monkeypatch.setenv("TRADEGOV_API_KEY", "secret")
+    tg = _import_client()
     responses = [
         {"status_code": 500},
         {"status_code": 502},
         {"json": {"results": [{"id": 1}], "next_page": None}},
     ]
     m = requests_mock.get("https://api.trade.gov/v1/entities/search", responses)
-    client = tg.TradeGovClient()
+    client = tg.TradeGovEntityClient()
     results = list(client.search_entities("foo"))
     assert results == [{"id": 1}]
     assert m.call_count == 3
 
 
-def test_empty_results(requests_mock):
-    tg = _import_client("secret")
+def test_empty_results(requests_mock, monkeypatch):
+    monkeypatch.setenv("TRADEGOV_API_KEY", "secret")
+    tg = _import_client()
     requests_mock.get(
         "https://api.trade.gov/v1/entities/search",
         json={"results": [], "next_page": None},
     )
-    client = tg.TradeGovClient()
+    client = tg.TradeGovEntityClient()
     results = list(client.search_entities("foo"))
     assert results == []
 
 
-def test_invalid_json(requests_mock):
-    tg = _import_client("secret")
+def test_invalid_json(requests_mock, monkeypatch):
+    monkeypatch.setenv("TRADEGOV_API_KEY", "secret")
+    tg = _import_client()
     requests_mock.get(
         "https://api.trade.gov/v1/entities/search",
         text="not json",
         status_code=200,
     )
-    client = tg.TradeGovClient()
+    client = tg.TradeGovEntityClient()
     with pytest.raises(tg.TradeGovError):
         list(client.search_entities("foo"))
 
 
-def test_missing_api_key():
-    tg = _import_client(None)
+def test_missing_api_key(monkeypatch):
+    monkeypatch.delenv("TRADEGOV_API_KEY", raising=False)
+    tg = _import_client()
     with pytest.raises(RuntimeError):
-        tg.TradeGovClient()
+        tg.TradeGovEntityClient()

--- a/tests/core/test_corpus_loader.py
+++ b/tests/core/test_corpus_loader.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+
+from earCrawler.core.ear_loader import EARLoader
+from earCrawler.core.nsf_loader import NSFLoader
+
+
+class _DummyFRClient:
+    def search_documents(self, query):  # pragma: no cover - simple stub
+        yield {"document_number": "1"}
+
+    def get_document(self, doc_number):  # pragma: no cover - simple stub
+        return {"html": "<p>Hello</p>"}
+
+
+class _DummyParser:
+    def run(self, fixtures_dir: Path, live: bool = False):  # pragma: no cover
+        return [{"case_number": "c1", "paragraphs": ["a", "b"]}]
+
+
+def test_loaders_output_shape(tmp_path: Path) -> None:
+    ear_loader = EARLoader(_DummyFRClient(), query="export")
+    nsf_loader = NSFLoader(_DummyParser(), tmp_path)
+    for loader in (ear_loader, nsf_loader):
+        paragraphs = loader.load_paragraphs()
+        assert paragraphs
+        for para in paragraphs:
+            assert set(para.keys()) == {"source", "text", "identifier"}


### PR DESCRIPTION
## Summary
- remove API key requirement from Federal Register client
- add Trade.gov entity client with environment variable support
- introduce CorpusLoader with EAR and NSF implementations and crawl CLI

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68961eef4ab48325bde18e94a46767c8