### PR TITLE
feat(kg): add TTL exporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [0.5.0]
 ### Added
 - feat(analytics): add cross-corpus reporting CLI and analytics module
+- feat(kg): add TTL exporter, ontology skeleton, and kg-export CLI command
+- chore(windows): add Jena env checker script and Java live-export pre-check
 
 ## [0.4.0]
 ### Added

--- a/README.md
+++ b/README.md
@@ -136,6 +136,21 @@ Write the results to a JSON file instead of stdout:
 python -m earCrawler.cli report --sources ear --type term-frequency --n 10 --out report.json
 ```
 
+## Knowledge Graph
+- `kg/ear_ontology.ttl`: RDF schema for paragraphs & entities.
+- `python -m earCrawler.cli kg-export`: Export TTL triples.
+- Load with: `tdb2.tdbloader --loc db/ kg/ear_triples.ttl`
+- Start Fuseki: `fuseki-server --config config/fuseki-config.ttl`
+
+### Windows 11 Setup for Jena
+Verify your environment before exporting triples:
+
+```powershell
+pwsh -File scripts/check_jena_env.ps1
+```
+Ensure a 64-bit Java ≥ 11 is installed, `apache-jena\bat` is on `PATH`,
+and run `git config --global core.longpaths true`.
+
 ## Core
 Combine both clients using the ``Crawler`` orchestration layer:
 

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -55,3 +55,13 @@ python -m earCrawler.cli report --sources ear nsf --type top-entities --entity O
 ```
 
 Use `--out report.json` to save the results to a file.
+
+## Phase B: Knowledge Graph
+- `kg/ear_ontology.ttl`: RDF schema for paragraphs & entities.
+- `python -m earCrawler.cli kg-export`: Export TTL triples.
+- Load with: `tdb2.tdbloader --loc db/ kg/ear_triples.ttl`
+- Start Fuseki: `fuseki-server --config config/fuseki-config.ttl`
+
+**Troubleshooting on Windows:**
+- If port 3030 is in use, start Fuseki with `--port 3031`.
+- Exclude your `db\` directory from Windows Defender to avoid file locks.

--- a/earCrawler/cli/__main__.py
+++ b/earCrawler/cli/__main__.py
@@ -159,6 +159,23 @@ def report(
                 click.echo(f"{name}\t{count}")
 
 
+@cli.command(name="kg-export")
+@click.option("--data-dir", default="data", help="Crawl JSONL directory.")
+@click.option("--out-ttl", default="kg/ear_triples.ttl", help="Output TTL file.")
+@click.option(
+    "--live/--offline",
+    default=False,
+    help="If --live, verify Java env before exporting TTL.",
+)
+def kg_export(data_dir: str, out_ttl: str, live: bool) -> None:
+    """Export paragraphs & entities to Turtle for Jena TDB2."""
+    from pathlib import Path
+    from earCrawler.kg.triples import export_triples
+
+    export_triples(Path(data_dir), Path(out_ttl), live=live)
+    click.echo(f"Written triples to {out_ttl}")
+
+
 def main() -> None:  # pragma: no cover - CLI entrypoint
     cli()
 

--- a/earCrawler/kg/__init__.py
+++ b/earCrawler/kg/__init__.py
@@ -1,0 +1,5 @@
+"""Knowledge graph utilities."""
+
+__all__ = ["export_triples"]
+
+from .triples import export_triples

--- a/earCrawler/kg/triples.py
+++ b/earCrawler/kg/triples.py
@@ -1,0 +1,46 @@
+from pathlib import Path
+import json
+import shutil
+import subprocess
+
+
+def _ensure_java() -> None:
+    java = shutil.which("java")
+    if not java:
+        raise RuntimeError("Java runtime not found. Install Temurin JDK ≥11.")
+    out = subprocess.check_output(["java", "-version"], stderr=subprocess.STDOUT, text=True)
+    major = int(out.split('"')[1].split(".")[0])
+    if major < 11:
+        raise RuntimeError(f"Java {major} detected, need ≥11")
+
+
+def export_triples(
+    data_dir: Path = Path("data"),
+    out_ttl: Path = Path("kg/ear_triples.ttl"),
+    live: bool = False,
+) -> None:
+    if live:
+        _ensure_java()
+    out_ttl.parent.mkdir(parents=True, exist_ok=True)
+    with out_ttl.open("w", encoding="utf-8") as f:
+        f.write(Path("kg/ear_ontology.ttl").read_text())
+        for source in ("ear", "nsf"):
+            fn = data_dir / f"{source}_corpus.jsonl"
+            if not fn.exists():
+                continue
+            for line in fn.read_text(encoding="utf-8").splitlines():
+                if not line:
+                    continue
+                rec = json.loads(line)
+                pid = rec["identifier"].replace(":", "_")
+                f.write(f"\nex:paragraph_{pid} a ex:Paragraph ;\n")
+                f.write(f'    ex:hasText """{rec["text"].replace("\"", "\\\"")}""" ;\n')
+                if source == "ear":
+                    part = rec["identifier"].split(":")[0]
+                    f.write(f'    ex:part "{part}" ;\n')
+                f.write("\n")
+                for ent in rec.get("entities", {}).get("orgs", []):
+                    eid = ent.replace(" ", "_")
+                    f.write(f"ex:paragraph_{pid} ex:mentions ex:entity_{eid} .\n")
+                    f.write(f"ex:entity_{eid} a ex:Entity ; rdfs:label \"{ent}\" .\n")
+

--- a/kg/ear_ontology.ttl
+++ b/kg/ear_ontology.ttl
@@ -1,0 +1,15 @@
+@prefix ex: <http://example.org/ear/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+# Classes
+ex:Paragraph   a rdfs:Class .
+ex:Entity      a rdfs:Class .
+ex:Case        a rdfs:Class .
+
+# Properties
+ex:hasText        a rdf:Property ; rdfs:domain ex:Paragraph ; rdfs:range xsd:string .
+ex:mentions       a rdf:Property ; rdfs:domain ex:Paragraph ; rdfs:range ex:Entity .
+ex:part           a rdf:Property ; rdfs:domain ex:Paragraph ; rdfs:range xsd:string .
+ex:caseNumber     a rdf:Property ; rdfs:domain ex:Case      ; rdfs:range xsd:string .

--- a/scripts/check_jena_env.ps1
+++ b/scripts/check_jena_env.ps1
@@ -1,0 +1,33 @@
+# Check Java
+$java = Get-Command java -ErrorAction SilentlyContinue
+if (-not $java) {
+  Write-Output "Java: WARN not found on PATH"
+} else {
+  $ver = & java -version 2>&1
+  $is64 = $ver -match "64-Bit"
+  if ($ver -match '"(\d+)' ) { $major = [int]$matches[1] } else { $major = 0 }
+  if ($major -ge 11 -and $is64) {
+    Write-Output "Java: OK"
+  } else {
+    Write-Output "Java: WARN $ver"
+  }
+}
+
+# Check Jena bat folder in PATH
+$pathItems = $env:PATH -split ';'
+$jena = $pathItems | Where-Object { $_ -match '\\bat(\\)?$' }
+if ($jena) {
+  Write-Output "Jena bat\\ folder: OK"
+} else {
+  Write-Output "Jena bat\\ folder: WARN"
+}
+
+# Check git longpaths
+$longpaths = git config --get core.longpaths 2>$null
+if ($longpaths -eq 'true') {
+  Write-Output "git core.longpaths=true: OK"
+} else {
+  Write-Output "git core.longpaths=true: WARN"
+}
+
+exit 0

--- a/tests/kg/test_triples.py
+++ b/tests/kg/test_triples.py
@@ -1,0 +1,18 @@
+import json
+from pathlib import Path
+
+from earCrawler.kg.triples import export_triples
+
+
+def test_export_triples_creates_file(tmp_path, monkeypatch):
+    # prepare a minimal JSONL fixture
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    rec = {"identifier": "123_0", "text": "Hello world", "entities": {"orgs": ["OrgX"]}}
+    (data_dir / "ear_corpus.jsonl").write_text(json.dumps(rec) + "\n")
+    (data_dir / "nsf_corpus.jsonl").write_text(json.dumps(rec) + "\n")
+    out_ttl = tmp_path / "kg.ttl"
+    export_triples(data_dir, out_ttl)
+    content = out_ttl.read_text()
+    assert "ex:paragraph_123_0 a ex:Paragraph" in content
+    assert "ex:entity_OrgX a ex:Entity" in content


### PR DESCRIPTION
## Summary
- add RDF ontology skeleton for paragraphs and entities
- export JSONL corpus to Turtle triples and CLI command `kg-export`
- document knowledge graph workflow in README and RUNBOOK
- add Windows Jena environment checker and `--live` flag with Java pre-check

## Testing
- `pytest -q`
- `python -m earCrawler.cli kg-export --help`
- `pwsh -NoLogo -File scripts/check_jena_env.ps1` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689649d5bc9c832588e181616e1fd926