### PR TITLE
feat(kg): add TDB2 loader CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.6.0]
+### Added
+- feat(kg): add kg-load CLI and loader module for Jena TDB2 import
+
 ## [0.5.0]
 ### Added
 - feat(analytics): add cross-corpus reporting CLI and analytics module

--- a/README.md
+++ b/README.md
@@ -139,8 +139,11 @@ python -m earCrawler.cli report --sources ear --type term-frequency --n 10 --out
 ## Knowledge Graph
 - `kg/ear_ontology.ttl`: RDF schema for paragraphs & entities.
 - `python -m earCrawler.cli kg-export`: Export TTL triples.
-- Load with: `tdb2.tdbloader --loc db/ kg/ear_triples.ttl`
 - Start Fuseki: `fuseki-server --config config/fuseki-config.ttl`
+
+### Loading into TDB2
+After exporting TTL:
+  python -m earCrawler.cli kg-load -t kg/ear_triples.ttl -d db/
 
 ### Windows 11 Setup for Jena
 Verify your environment before exporting triples:

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -59,9 +59,12 @@ Use `--out report.json` to save the results to a file.
 ## Phase B: Knowledge Graph
 - `kg/ear_ontology.ttl`: RDF schema for paragraphs & entities.
 - `python -m earCrawler.cli kg-export`: Export TTL triples.
-- Load with: `tdb2.tdbloader --loc db/ kg/ear_triples.ttl`
 - Start Fuseki: `fuseki-server --config config/fuseki-config.ttl`
 
 **Troubleshooting on Windows:**
 - If port 3030 is in use, start Fuseki with `--port 3031`.
 - Exclude your `db\` directory from Windows Defender to avoid file locks.
+
+# Phase B.2
+Use `kg-load` to ingest triples into TDB2.  
+Ensure `tdb2.tdbloader` is on PATH (Jena’s bat\ folder).

--- a/earCrawler/cli/__main__.py
+++ b/earCrawler/cli/__main__.py
@@ -176,6 +176,21 @@ def kg_export(data_dir: str, out_ttl: str, live: bool) -> None:
     click.echo(f"Written triples to {out_ttl}")
 
 
+@click.command()
+@click.option("--ttl", "-t", default="kg/ear_triples.ttl", help="Turtle file to load.")
+@click.option("--db", "-d", default="db", help="TDB2 DB directory.")
+def kg_load(ttl: str, db: str) -> None:
+    """Load Turtle into Jena TDB2 store."""
+    from pathlib import Path
+    from earCrawler.kg.loader import load_tdb
+
+    load_tdb(Path(ttl), Path(db))
+    click.echo(f"Loaded {ttl} into TDB2 at {db}")
+
+
+cli.add_command(kg_load, name="kg-load")
+
+
 def main() -> None:  # pragma: no cover - CLI entrypoint
     cli()
 

--- a/earCrawler/kg/__init__.py
+++ b/earCrawler/kg/__init__.py
@@ -1,5 +1,6 @@
 """Knowledge graph utilities."""
 
-__all__ = ["export_triples"]
+__all__ = ["export_triples", "load_tdb"]
 
 from .triples import export_triples
+from .loader import load_tdb

--- a/earCrawler/kg/loader.py
+++ b/earCrawler/kg/loader.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+"""Utilities for loading triples into a local Jena TDB2 store."""
+
+from pathlib import Path
+import subprocess
+
+
+def load_tdb(ttl_path: Path, db_dir: Path = Path("db")) -> None:
+    """Loads TTL triples into a Jena TDB2 database at db_dir.
+    Requires `tdb2.tdbloader` on PATH.
+    """
+    db_dir.mkdir(parents=True, exist_ok=True)
+    cmd = ["tdb2.tdbloader", "--loc", str(db_dir), str(ttl_path)]
+    subprocess.check_call(cmd)

--- a/tests/kg/test_loader.py
+++ b/tests/kg/test_loader.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+from unittest.mock import patch
+
+from earCrawler.kg.loader import load_tdb
+
+
+def test_load_tdb_invokes_tdbloader_and_creates_dir(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    Path("foo.ttl").write_text("")
+    with patch("subprocess.check_call") as mock_call:
+        load_tdb(Path("foo.ttl"), Path("mydb"))
+        mock_call.assert_called_once_with(
+            ["tdb2.tdbloader", "--loc", "mydb", "foo.ttl"]
+        )
+    assert Path("mydb").is_dir()


### PR DESCRIPTION
## Summary
- add loader module to ingest Turtle into local Jena TDB2
- expose kg-load CLI command for loading exported triples
- document kg-load usage and update changelog and runbook

## Testing
- `pytest -q`
- `PATH=/tmp:$PATH python -m earCrawler.cli kg-load --ttl foo.ttl --db bar`

------
https://chatgpt.com/codex/tasks/task_e_68965dca9798832596d9c19262e6a4c9