### PR TITLE
feat(kg): add Fuseki serve and SPARQL query CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [0.7.0]
+### Added
+- feat(kg): add Fuseki serve (kg-serve) and SPARQL query (kg-query) commands
+- feat(kg): Windows-first absolute invocation of local Jena (auto-download)
+- test(kg): offline tests for Fuseki launcher and SPARQL client
+- docs(kg): README/RUNBOOK updates with Windows examples
+
 ## [0.6.1]
 ### Added
 - feat(kg): auto-install Apache Jena into tools/jena and invoke TDB2 loader by absolute path on Windows

--- a/README.md
+++ b/README.md
@@ -150,6 +150,27 @@ python -m earCrawler.cli kg-load --ttl kg\ear_triples.ttl --db db
 ```
 To disable auto-download, add `--no-auto-install`. By default, Jena is fetched once and cached in `tools\jena`.
 
+### Phase B.3 — Serve & Query
+
+```powershell
+# Serve (foreground)
+python -m earCrawler.cli kg-serve -d db -p 3030 --dataset /ear
+
+# Dry run (print command)
+python -m earCrawler.cli kg-serve --dry-run
+
+# Query (SELECT)
+python -m earCrawler.cli kg-query --sparql "SELECT * WHERE { ?s ?p ?o } LIMIT 5" -o data\rows.json
+
+# Query (CONSTRUCT)
+python -m earCrawler.cli kg-query --form construct -q "CONSTRUCT WHERE { ?s ?p ?o } LIMIT 10" -o data\graph.nt
+```
+
+**Troubleshooting:**
+- If port 3030 is in use, specify a free one with `-p 3031`.
+- On first run, Jena auto-downloads to `.\tools\jena`; no PATH changes required.
+
+
 ## Core
 Combine both clients using the ``Crawler`` orchestration layer:
 

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -69,3 +69,21 @@ Use `--out report.json` to save the results to a file.
 
 # Phase B.2
 Use `kg-load` to ingest triples into TDB2.
+
+## Phase B.3 — Serve & Query
+```cmd
+# Serve (foreground)
+python -m earCrawler.cli kg-serve -d db -p 3030 --dataset /ear
+
+# Dry run (print command)
+python -m earCrawler.cli kg-serve --dry-run
+
+# Query (SELECT)
+python -m earCrawler.cli kg-query --sparql "SELECT * WHERE { ?s ?p ?o } LIMIT 5" -o data\rows.json
+
+# Query (CONSTRUCT)
+python -m earCrawler.cli kg-query --form construct -q "CONSTRUCT WHERE { ?s ?p ?o } LIMIT 10" -o data\graph.nt
+```
+
+Stop the server with `Ctrl+C` in the console. For programmatic use, the
+``running_fuseki`` context manager in ``earCrawler.kg.fuseki`` ensures cleanup.

--- a/earCrawler/kg/__init__.py
+++ b/earCrawler/kg/__init__.py
@@ -1,6 +1,15 @@
 """Knowledge graph utilities."""
 
-__all__ = ["export_triples", "load_tdb"]
+__all__ = [
+    "export_triples",
+    "load_tdb",
+    "start_fuseki",
+    "running_fuseki",
+    "build_fuseki_cmd",
+    "SPARQLClient",
+]
 
 from .triples import export_triples
 from .loader import load_tdb
+from .fuseki import start_fuseki, running_fuseki, build_fuseki_cmd
+from .sparql import SPARQLClient

--- a/earCrawler/kg/fuseki.py
+++ b/earCrawler/kg/fuseki.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+"""Helpers for launching a local Apache Jena Fuseki server."""
+
+from pathlib import Path
+import os
+import subprocess
+import time
+import contextlib
+import socket
+from typing import Optional
+
+import requests
+
+from earCrawler.utils.jena_tools import ensure_jena
+
+
+def fuseki_server_path() -> Path:
+    """Return the absolute path to the Fuseki server executable.
+
+    On Windows the batch file is under ``tools/jena/bat`` while on POSIX
+    systems it lives in ``tools/jena/bin``. The path is resolved after
+    ensuring that Jena is installed.
+    """
+
+    jena_home = ensure_jena(download=True)
+    if os.name == "nt":
+        exe = jena_home / "bat" / "fuseki-server.bat"
+    else:
+        exe = jena_home / "bin" / "fuseki-server"
+    return exe.resolve()
+
+
+def build_fuseki_cmd(
+    db_dir: Path, dataset: str, port: int, java_opts: Optional[str] = None
+) -> list[str]:
+    """Build the Fuseki server command line.
+
+    Parameters are passed as CLI arguments; any ``java_opts`` should be handled
+    by setting the ``FUSEKI_JAVA_OPTS`` environment variable when launching the
+    process.
+    """
+
+    server = fuseki_server_path()
+    cmd = [
+        str(server),
+        "--port",
+        str(port),
+        "--loc",
+        str(Path(db_dir).resolve()),
+        dataset,
+    ]
+    return cmd
+
+
+def _port_in_use(port: int) -> bool:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.settimeout(0.5)
+        return sock.connect_ex(("localhost", port)) == 0
+
+
+def start_fuseki(
+    db_dir: Path,
+    dataset: str = "/ear",
+    port: int = 3030,
+    wait: bool = True,
+    timeout_s: int = 30,
+    java_opts: Optional[str] = None,
+) -> subprocess.Popen:
+    """Start a local Fuseki process serving ``db_dir`` on ``port``.
+
+    If ``wait`` is True the function blocks until ``/$/ping`` responds or the
+    timeout elapses. A ``RuntimeError`` is raised on failure or when the port is
+    already in use.
+    """
+
+    if _port_in_use(port):
+        raise RuntimeError(f"Port {port} already in use")
+
+    cmd = build_fuseki_cmd(db_dir, dataset, port, java_opts)
+    env = os.environ.copy()
+    if java_opts:
+        env["FUSEKI_JAVA_OPTS"] = java_opts
+
+    proc = subprocess.Popen(cmd, env=env, shell=False)
+
+    if not wait:
+        return proc
+
+    try:
+        wait_until_ready(port, timeout_s=timeout_s, proc=proc)
+    except Exception as exc:  # pragma: no cover - error path
+        proc.terminate()
+        raise RuntimeError(f"Fuseki failed to start: {exc}") from exc
+
+    return proc
+
+
+def wait_until_ready(port: int, timeout_s: int = 30, proc: subprocess.Popen | None = None) -> None:
+    """Poll ``/$/ping`` until Fuseki responds or timeout elapses."""
+
+    deadline = time.time() + timeout_s
+    delay = 0.1
+    url = f"http://localhost:{port}/$/ping"
+    while time.time() < deadline:
+        if proc is not None and proc.poll() is not None:
+            raise RuntimeError("Fuseki process exited prematurely")
+        try:
+            resp = requests.get(url, timeout=2)
+            if resp.status_code == 200:
+                return
+        except requests.RequestException:
+            pass
+        time.sleep(delay)
+        delay = min(delay * 1.5, 1.0)
+    raise RuntimeError("Fuseki server did not become ready in time")
+
+
+@contextlib.contextmanager
+def running_fuseki(
+    db_dir: Path,
+    dataset: str = "/ear",
+    port: int = 3030,
+    java_opts: Optional[str] = None,
+):
+    """Context manager to start and terminate Fuseki."""
+
+    proc = start_fuseki(db_dir, dataset=dataset, port=port, wait=True, java_opts=java_opts)
+    try:
+        yield proc
+    finally:  # pragma: no branch - cleanup
+        if proc.poll() is None:
+            proc.terminate()
+            try:
+                proc.wait(timeout=5)
+            except Exception:
+                pass

--- a/earCrawler/kg/sparql.py
+++ b/earCrawler/kg/sparql.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+"""Minimal SPARQL HTTP client for local Fuseki use."""
+
+from typing import Dict, Any, Literal, Optional
+import requests
+
+
+class SPARQLClient:
+    """Tiny wrapper around ``requests`` for talking to Fuseki."""
+
+    def __init__(self, endpoint: str = "http://localhost:3030/ear/sparql", timeout: int = 15):
+        self.endpoint = endpoint
+        self.session = requests.Session()
+        self.timeout = timeout
+
+    def _get(self, query: str, accept: str) -> requests.Response:
+        resp = self.session.get(
+            self.endpoint,
+            params={"query": query},
+            headers={"Accept": accept},
+            timeout=self.timeout,
+        )
+        return resp
+
+    def select(self, query: str) -> Dict[str, Any]:
+        """Execute a ``SELECT`` query and return parsed JSON."""
+
+        resp = self._get(query, "application/sparql-results+json")
+        if resp.status_code != 200:
+            raise RuntimeError(f"SPARQL SELECT failed: {resp.status_code}")
+        try:
+            data = resp.json()
+        except ValueError as exc:  # pragma: no cover - invalid server response
+            raise RuntimeError("Invalid JSON from SPARQL endpoint") from exc
+        return data
+
+    def ask(self, query: str) -> bool:
+        """Execute an ``ASK`` query and return the boolean result."""
+
+        data = self.select(query)
+        try:
+            return bool(data["boolean"])
+        except KeyError as exc:  # pragma: no cover
+            raise RuntimeError("Missing boolean result") from exc
+
+    def construct(self, query: str) -> str:
+        """Execute a ``CONSTRUCT`` query returning N-Triples."""
+
+        resp = self._get(query, "application/n-triples")
+        if resp.status_code != 200:
+            raise RuntimeError(f"SPARQL CONSTRUCT failed: {resp.status_code}")
+        return resp.text

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "earCrawler"
-version = "0.4.0"
+version = "0.7.0"
 description = "EAR AI ingestion, RAG, and analytics pipeline"
 authors = [{ name = "Your Name", email = "you@example.com" }]
 license = { text = "MIT" }

--- a/tests/kg/test_fuseki.py
+++ b/tests/kg/test_fuseki.py
@@ -1,0 +1,73 @@
+from pathlib import Path
+
+import pytest
+
+import earCrawler.kg.fuseki as fuseki
+
+
+def test_build_fuseki_cmd_windows_paths(tmp_path, monkeypatch):
+    jena_home = tmp_path / "tools" / "jena"
+    server = jena_home / "bat" / "fuseki-server.bat"
+    server.parent.mkdir(parents=True)
+    server.write_text("")
+    monkeypatch.setattr(fuseki, "ensure_jena", lambda download=True: jena_home)
+    monkeypatch.setattr(fuseki, "fuseki_server_path", lambda: server)
+    cmd = fuseki.build_fuseki_cmd(tmp_path / "db", "/ear", 3030)
+    assert Path(cmd[0]).resolve() == server.resolve()
+    assert "--loc" in cmd
+    assert cmd[-1] == "/ear"
+
+
+class DummyProc:
+    pid = 123
+
+    def __init__(self, *a, **kw):
+        self.returncode = None
+
+    def poll(self):
+        return self.returncode
+
+    def terminate(self):
+        self.returncode = 0
+
+    def wait(self, timeout=None):  # pragma: no cover - not used
+        return self.returncode
+
+
+def test_start_fuseki_dry_waits_and_times_out(tmp_path, monkeypatch):
+    jena_home = tmp_path / "tools" / "jena"
+    (jena_home / "bin").mkdir(parents=True)
+    (jena_home / "bin" / "fuseki-server").write_text("")
+    monkeypatch.setattr(fuseki, "ensure_jena", lambda download=True: jena_home)
+
+    monkeypatch.setattr(fuseki.subprocess, "Popen", lambda *a, **k: DummyProc())
+
+    def bad_get(*a, **k):
+        raise fuseki.requests.RequestException("fail")
+
+    monkeypatch.setattr(fuseki.requests, "get", bad_get)
+
+    times = iter([0, 0.6, 1.2])
+    monkeypatch.setattr(fuseki.time, "time", lambda: next(times))
+    monkeypatch.setattr(fuseki.time, "sleep", lambda _t: None)
+
+    with pytest.raises(RuntimeError):
+        fuseki.start_fuseki(tmp_path / "db", timeout_s=1)
+
+
+def test_start_fuseki_no_wait_returns_popen(tmp_path, monkeypatch):
+    jena_home = tmp_path / "tools" / "jena"
+    (jena_home / "bin").mkdir(parents=True)
+    (jena_home / "bin" / "fuseki-server").write_text("")
+    monkeypatch.setattr(fuseki, "ensure_jena", lambda download=True: jena_home)
+
+    sentinel = object()
+    monkeypatch.setattr(fuseki.subprocess, "Popen", lambda *a, **k: sentinel)
+
+    def raiser(*a, **k):  # pragma: no cover - should not run
+        raise AssertionError("HTTP call made")
+
+    monkeypatch.setattr(fuseki.requests, "get", raiser)
+
+    proc = fuseki.start_fuseki(tmp_path / "db", wait=False)
+    assert proc is sentinel

--- a/tests/kg/test_sparql.py
+++ b/tests/kg/test_sparql.py
@@ -1,0 +1,75 @@
+import json
+from pathlib import Path
+
+from click.testing import CliRunner
+
+import earCrawler.cli.__main__ as cli
+import earCrawler.kg.sparql as sparql
+
+
+def test_kg_query_select(tmp_path, monkeypatch):
+    data = {
+        "head": {"vars": ["s"]},
+        "results": {
+            "bindings": [
+                {"s": {"type": "uri", "value": "a"}},
+                {"s": {"type": "uri", "value": "b"}},
+            ]
+        },
+    }
+
+    class Resp:
+        status_code = 200
+
+        def json(self):
+            return data
+
+    def fake_get(self, url, params=None, headers=None, timeout=None):
+        return Resp()
+
+    monkeypatch.setattr(sparql.requests.Session, "get", fake_get)
+    runner = CliRunner()
+    out = tmp_path / "rows.json"
+    result = runner.invoke(cli.kg_query, ["--sparql", "SELECT * WHERE { ?s ?p ?o }", "-o", str(out)])
+    assert result.exit_code == 0
+    content = json.loads(out.read_text())
+    assert len(content["results"]["bindings"]) == 2
+
+
+def test_kg_query_ask(tmp_path, monkeypatch):
+    class Resp:
+        status_code = 200
+
+        def json(self):
+            return {"boolean": True}
+
+    def fake_get(self, url, params=None, headers=None, timeout=None):
+        return Resp()
+
+    monkeypatch.setattr(sparql.requests.Session, "get", fake_get)
+    runner = CliRunner()
+    out = tmp_path / "ask.json"
+    result = runner.invoke(cli.kg_query, ["--form", "ask", "--sparql", "ASK { }", "-o", str(out)])
+    assert result.exit_code == 0
+    content = json.loads(out.read_text())
+    assert content["boolean"] is True
+
+
+def test_kg_query_construct(tmp_path, monkeypatch):
+    class Resp:
+        status_code = 200
+        text = "<http://example.org/a> <http://example.org/b> <http://example.org/c> ."
+
+    def fake_get(self, url, params=None, headers=None, timeout=None):
+        return Resp()
+
+    monkeypatch.setattr(sparql.requests.Session, "get", fake_get)
+    runner = CliRunner()
+    out = tmp_path / "graph.nt"
+    result = runner.invoke(
+        cli.kg_query,
+        ["--form", "construct", "--sparql", "CONSTRUCT WHERE { ?s ?p ?o }", "-o", str(out)],
+    )
+    assert result.exit_code == 0
+    text = out.read_text()
+    assert "example.org/a" in text


### PR DESCRIPTION
## Summary
- add `kg-serve` command to run local Fuseki using absolute Jena paths
- add tiny `SPARQLClient` and `kg-query` CLI for offline queries
- document Phase B.3 serve & query workflow on Windows

## Testing
- `pytest -q --disable-warnings --maxfail=1`

------
https://chatgpt.com/codex/tasks/task_e_689a4efb5ec08325aa6f0256bd443e18