### PR TITLE
Escape triple quoted text

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+exclude = .venv,build,dist

--- a/earCrawler/kg/triples.py
+++ b/earCrawler/kg/triples.py
@@ -19,7 +19,8 @@ def export_triples(
                 rec = json.loads(line)
                 pid = rec["identifier"].replace(":", "_")
                 f.write(f"\nex:paragraph_{pid} a ex:Paragraph ;\n")
-                f.write(f'    ex:hasText """{rec["text"].replace("\"", "\\\"")}""" ;\n')
+                escaped_text = rec["text"].replace('"', '\\"')
+                f.write(f'    ex:hasText """{escaped_text}""" ;\n')
                 if source == "ear":
                     part = rec["identifier"].split(":")[0]
                     f.write(f'    ex:part "{part}" ;\n')


### PR DESCRIPTION
## Summary
- safely escape paragraph text when exporting triples

## Testing
- `python -m py_compile earCrawler/kg/triples.py`
- `python - <<'PY'
import importlib
import earCrawler.kg.triples as t
importlib.reload(t)
print('Imported again:', t.export_triples.__name__)
PY`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689b6eb9613083258e26c61a97f2553b