### PR TITLE
feat(kg): SPARQL sanity checks + SHACL validation (B.5)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,18 @@ jobs:
       - name: Tests
         run: pytest -q --disable-warnings --maxfail=1
 
+      - name: Smoke test emit and validate
+        shell: pwsh
+        run: |
+          python -m cli.kg_emit --sources ear --sources nsf --in tests\kg\fixtures --out tests\kg\artifacts
+          python -m cli.kg_validate --glob "tests\kg\artifacts\*.ttl"
+          python - <<'PY'
+          import glob
+          from rdflib import Graph
+          for p in glob.glob(r"tests\kg\artifacts\*.ttl"):
+              Graph().parse(p, format="turtle")
+          PY
+
   gpu:
     runs-on: ubuntu-latest
     continue-on-error: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [0.9.0] - 2025-08-12
+### Added
+- SPARQL sanity checks and SHACL validation (`kg-validate`) for EAR/NSF TTLs.
+- Windows-first CI smoke tests for emit + validate.
+
 ## [0.8.0]
 ### Added
 - feat(kg): ontology + TTL emitters for EAR/NSF with deterministic output; CLI `kg-emit`

--- a/README.md
+++ b/README.md
@@ -55,6 +55,14 @@ Run the GPU tests:
 pytest -m gpu
 ```
 
+## Validation
+Run sanity checks on emitted Turtle before using them.
+
+```powershell
+python -m cli.kg_emit --sources ear --sources nsf --in data --out data\kg
+python -m cli.kg_validate --glob "data\kg\*.ttl"
+```
+
 ## Repository Structure
 - `api_clients/` – clients for Trade.gov and Federal Register APIs.
 - `tests/` – unit tests covering success and failure scenarios.

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -101,3 +101,10 @@ python -m earCrawler.cli kg-query --form construct -q "CONSTRUCT WHERE { ?s ?p ?
 
 Stop the server with `Ctrl+C` in the console. For programmatic use, the
 ``running_fuseki`` context manager in ``earCrawler.kg.fuseki`` ensures cleanup.
+
+## Validation Troubleshooting
+
+| Violation | Fix |
+| --- | --- |
+| missing_provenance | Ensure the source JSONL has `source_url`, `prov:wasDerivedFrom`, and `date` fields. |
+| entity_mentions_without_type | Regenerate TTL ensuring each entity node is typed `ent:Entity`. |

--- a/cli/kg_emit.py
+++ b/cli/kg_emit.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+"""Emit EAR/NSF corpora to Turtle files.
+
+Secrets such as Trade.gov or Federal Register API keys must be stored in
+Windows Credential Manager or provided via environment variables, never
+hard-coded.
+"""
+
+from pathlib import Path
+
+import click
+
+from earCrawler.kg.emit_ear import emit_ear
+from earCrawler.kg.emit_nsf import emit_nsf
+
+
+@click.command()
+@click.option(
+    "--sources",
+    "-s",
+    multiple=True,
+    type=click.Choice(["ear", "nsf"]),
+    required=True,
+    help="Repeatable: e.g., -s ear -s nsf",
+)
+@click.option(
+    "--in",
+    "in_dir",
+    "-i",
+    type=click.Path(file_okay=False, path_type=Path),
+    default=Path("data"),
+    show_default=True,
+    help="Input data directory.",
+)
+@click.option(
+    "--out",
+    "out_dir",
+    "-o",
+    type=click.Path(file_okay=False, path_type=Path),
+    default=Path("data") / "kg",
+    show_default=True,
+    help="Output directory for TTL files.",
+)
+def main(sources: tuple[str, ...], in_dir: Path, out_dir: Path) -> None:
+    """Emit RDF/Turtle for selected sources."""
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    for src in sources:
+        try:
+            if src == "ear":
+                out_path, count = emit_ear(in_dir, out_dir)
+            elif src == "nsf":
+                out_path, count = emit_nsf(in_dir, out_dir)
+            else:  # pragma: no cover - click restricts choices
+                raise click.ClickException(f"Unknown source: {src}")
+            click.echo(f"{src}: {count} triples -> {out_path}")
+        except Exception as exc:  # pragma: no cover - runtime errors
+            raise click.ClickException(str(exc))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/cli/kg_validate.py
+++ b/cli/kg_validate.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+"""Validate emitted Turtle files using SPARQL checks and SHACL.
+
+API keys for external services must be stored in Windows Credential Manager or
+provided via environment variables; never embed secrets in code or tests.
+"""
+
+from glob import glob
+from pathlib import Path
+from typing import List
+
+import click
+
+from earCrawler.kg.validate import validate_files
+
+
+@click.command()
+@click.option("--ttl", "ttls", multiple=True, type=click.Path(path_type=Path), help="Path to TTL file.")
+@click.option("--glob", "glob_pattern", type=str, help="Glob pattern for TTL files.")
+@click.option(
+    "--shapes",
+    type=click.Path(path_type=Path),
+    default=Path(__file__).resolve().parent.parent / "earCrawler" / "kg" / "shapes.ttl",
+    show_default=True,
+    help="Path to SHACL shapes graph.",
+)
+@click.option(
+    "--fail-on",
+    type=click.Choice(["any", "shacl-only", "sparql-only"]),
+    default="any",
+    show_default=True,
+    help="What violations trigger a non-zero exit code.",
+)
+def main(ttls: tuple[Path, ...], glob_pattern: str | None, shapes: Path, fail_on: str) -> None:
+    """Entry point for ``kg-validate`` CLI."""
+
+    paths: List[str] = []
+    if glob_pattern:
+        paths.extend(glob(glob_pattern))
+    paths.extend(str(p) for p in ttls)
+    exit_code = validate_files(paths, str(shapes), fail_on=fail_on)
+    raise SystemExit(exit_code)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/earCrawler/__init__.py
+++ b/earCrawler/__init__.py
@@ -7,6 +7,6 @@ from importlib.metadata import PackageNotFoundError, version
 try:
     __version__ = version("earCrawler")
 except PackageNotFoundError:  # pragma: no cover - package not installed
-    __version__ = "0.8.0"
+    __version__ = "0.9.0"
 
 __all__ = ["__version__"]

--- a/earCrawler/kg/emit_nsf.py
+++ b/earCrawler/kg/emit_nsf.py
@@ -16,7 +16,7 @@ from .ontology import (
     DCT,
     PROV,
     graph_with_prefixes,
-    iri_for_paragraph,
+    iri_for_paragraph, iri_for_section,
     safe_literal,
 )
 
@@ -60,6 +60,8 @@ def emit_nsf(in_dir: Path, out_dir: Path) -> tuple[Path, int]:
     out_path = out_dir / "nsf.ttl"
 
     g = graph_with_prefixes()
+    reg_iri = EAR_NS["reg"]
+    g.add((reg_iri, RDF.type, EAR_NS.Reg))
 
     with in_path.open("r", encoding="utf-8") as f:
         for line in f:
@@ -71,6 +73,11 @@ def emit_nsf(in_dir: Path, out_dir: Path) -> tuple[Path, int]:
                 continue
             para_iri = iri_for_paragraph(para_hash)
             g.add((para_iri, RDF.type, EAR_NS.Paragraph))
+            sec_id = rec.get("section") or rec.get("id")
+            sec_iri = iri_for_section(str(sec_id))
+            g.add((sec_iri, RDF.type, EAR_NS.Section))
+            g.add((reg_iri, EAR_NS.hasSection, sec_iri))
+            g.add((sec_iri, EAR_NS.hasParagraph, para_iri))
             source = rec.get("source_url")
             if source:
                 if _is_url(source):

--- a/earCrawler/kg/queries.py
+++ b/earCrawler/kg/queries.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+"""Registry of SPARQL sanity check queries.
+
+Each query is a deterministic ``SELECT`` that returns offending nodes.  The
+keys in :data:`QUERIES` are sorted to provide stable output ordering.
+"""
+
+from collections.abc import Iterable
+
+# Query strings are defined with compact prefixes for readability.
+QUERIES: dict[str, str] = {
+    "orphan_sections": """
+PREFIX ear: <https://example.org/ear#>
+SELECT ?section WHERE {
+  ?section a ear:Section .
+  FILTER NOT EXISTS { ?reg a ear:Reg ; ear:hasSection ?section . }
+}
+""".strip(),
+    "orphan_paragraphs": """
+PREFIX ear: <https://example.org/ear#>
+SELECT ?para WHERE {
+  ?para a ear:Paragraph .
+  FILTER NOT EXISTS { ?sec a ear:Section ; ear:hasParagraph ?para . }
+}
+""".strip(),
+    "missing_provenance": """
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX prov: <http://www.w3.org/ns/prov#>
+PREFIX ear: <https://example.org/ear#>
+SELECT ?para WHERE {
+  ?para a ear:Paragraph .
+  FILTER (
+    NOT EXISTS { ?para dct:source ?s } ||
+    NOT EXISTS { ?para prov:wasDerivedFrom ?d } ||
+    NOT EXISTS { ?para dct:issued ?date }
+  )
+}
+""".strip(),
+    "dangling_citations": """
+PREFIX ear: <https://example.org/ear#>
+SELECT ?cit WHERE {
+  ?cit a ear:Citation .
+  FILTER NOT EXISTS { ?p a ear:Paragraph ; ear:cites ?cit . }
+}
+""".strip(),
+    "entity_mentions_without_type": """
+PREFIX ent: <https://example.org/entity#>
+SELECT ?n WHERE {
+  ?n ?p ?o .
+  FILTER(STRSTARTS(STR(?n), "https://example.org/entity#")) .
+  FILTER NOT EXISTS { ?n a ent:Entity . }
+}
+""".strip(),
+}
+
+
+def iter_queries() -> Iterable[tuple[str, str]]:
+    """Yield ``(name, query)`` pairs in a deterministic order."""
+
+    for name in sorted(QUERIES):
+        yield name, QUERIES[name]
+
+
+__all__ = ["QUERIES", "iter_queries"]

--- a/earCrawler/kg/shapes.ttl
+++ b/earCrawler/kg/shapes.ttl
@@ -1,0 +1,56 @@
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix ear: <https://example.org/ear#> .
+@prefix ent: <https://example.org/entity#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+
+# Shapes for core EAR ontology classes.
+
+ear:RegShape a sh:NodeShape ;
+    sh:targetClass ear:Reg ;
+    sh:property [
+        sh:path ear:hasSection ;
+        sh:minCount 1 ;
+    ] .
+
+ear:SectionShape a sh:NodeShape ;
+    sh:targetClass ear:Section ;
+    sh:property [
+        sh:path [ sh:inversePath ear:hasSection ] ;
+        sh:minCount 1 ;
+    ] .
+
+ear:ParagraphShape a sh:NodeShape ;
+    sh:targetClass ear:Paragraph ;
+    sh:property [
+        sh:path [ sh:inversePath ear:hasParagraph ] ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+    ] , [
+        sh:path dct:source ;
+        sh:minCount 1 ;
+    ] , [
+        sh:path prov:wasDerivedFrom ;
+        sh:minCount 1 ;
+    ] , [
+        sh:path dct:issued ;
+        sh:minCount 1 ;
+        sh:datatype xsd:date ;
+    ] .
+
+ear:CitationShape a sh:NodeShape ;
+    sh:targetClass ear:Citation ;
+    sh:property [
+        sh:path [ sh:inversePath ear:cites ] ;
+        sh:minCount 1 ;
+    ] .
+
+ent:EntityShape a sh:NodeShape ;
+    sh:targetClass ent:Entity ;
+    sh:property [
+        sh:path prov:wasDerivedFrom ;
+        sh:minCount 1 ;
+    ] .

--- a/earCrawler/kg/validate.py
+++ b/earCrawler/kg/validate.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+"""Validation helpers for EAR knowledge graph Turtle files.
+
+The functions here perform offline SPARQL sanity checks and SHACL shape
+validation without any network access.  Keep API keys in Windows Credential
+Manager or your vault; do not hard-code secrets in code.
+"""
+
+from pathlib import Path
+from typing import Iterable
+
+from rdflib import Graph
+from pyshacl import validate as shacl_validate
+
+from .queries import iter_queries
+
+
+def run_sparql_checks(graph: Graph) -> list[tuple[str, int]]:
+    """Run all SPARQL sanity checks over ``graph``.
+
+    Returns a list of ``(check_name, violation_count)`` sorted by check name.
+    """
+
+    results: list[tuple[str, int]] = []
+    for name, query in iter_queries():
+        qres = graph.query(query)
+        count = len(list(qres))
+        results.append((name, count))
+    return results
+
+
+def run_shacl(graph: Graph, shapes_path: str) -> tuple[bool, Graph, str]:
+    """Validate ``graph`` against ``shapes_path`` using ``pyshacl``."""
+
+    conforms, results_graph, results_text = shacl_validate(
+        graph,
+        shacl_graph=Graph().parse(shapes_path, format="turtle"),
+        advanced=True,
+        inference="rdfs",
+        abort_on_first=False,
+    )
+    return bool(conforms), results_graph, str(results_text)
+
+
+def _load_graph(path: Path) -> Graph:
+    """Parse ``path`` into a graph."""
+
+    g = Graph()
+    g.parse(path, format="turtle")
+    return g
+
+
+def validate_files(paths: Iterable[str], shapes_path: str, *, fail_on: str = "any") -> int:
+    """Validate one or more Turtle files.
+
+    Parameters
+    ----------
+    paths:
+        Iterable of file paths to Turtle documents.
+    shapes_path:
+        Path to a SHACL shapes graph.
+    fail_on:
+        One of ``"any"``, ``"shacl-only"``, ``"sparql-only"`` controlling the
+        exit behaviour.
+
+    Returns
+    -------
+    int
+        ``0`` if clean, ``1`` if violations are found, ``2`` on usage errors.
+    """
+
+    files = sorted({str(Path(p)) for p in paths})
+    if not files:
+        print("No TTL files provided", flush=True)
+        return 2
+
+    shapes = Path(shapes_path)
+    if not shapes.is_file():
+        print(f"Shapes file not found: {shapes}", flush=True)
+        return 2
+
+    headers = ["file", "shacl"] + [name for name, _ in iter_queries()]
+    rows: list[list[str]] = []
+    any_sparql = False
+    any_shacl = False
+
+    for file in files:
+        fp = Path(file)
+        if not fp.is_file():
+            print(f"File not found: {file}", flush=True)
+            return 2
+        g = _load_graph(fp)
+        sparql_counts = run_sparql_checks(g)
+        conforms, _, _ = run_shacl(g, str(shapes))
+        row = [file, str(conforms)]
+        for name, count in sparql_counts:
+            row.append(str(count))
+            if count:
+                any_sparql = True
+        if not conforms:
+            any_shacl = True
+        rows.append(row)
+
+    # Deterministic table output
+    col_widths = [max(len(h), *(len(r[i]) for r in rows)) for i, h in enumerate(headers)]
+    header_line = " ".join(h.ljust(col_widths[i]) for i, h in enumerate(headers))
+    print(header_line)
+    for r in rows:
+        print(" ".join(r[i].ljust(col_widths[i]) for i in range(len(headers))))
+
+    if fail_on == "any":
+        return 1 if any_sparql or any_shacl else 0
+    if fail_on == "shacl-only":
+        return 1 if any_shacl else 0
+    if fail_on == "sparql-only":
+        return 1 if any_sparql else 0
+    return 2
+
+
+__all__ = ["run_sparql_checks", "run_shacl", "validate_files"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "earCrawler"
-version = "0.8.0"
+version = "0.9.0"
 description = "EAR AI ingestion, RAG, and analytics pipeline"
 authors = [{ name = "Your Name", email = "you@example.com" }]
 license = { text = "MIT" }
@@ -12,7 +12,9 @@ dependencies = [
   "tabulate>=0.8.9",
   "beautifulsoup4>=4.12.0",
   "rdflib==6.3.2",
+  "pyshacl==0.25.0",
 ]
 
 [project.scripts]
 earCrawler = "earCrawler.cli.__main__:main"
+kg-validate = "cli.kg_validate:main"

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ bitsandbytes==0.43.1
 peft==0.11.1
 transformers==4.39.3
 fastapi==0.116.1
-pyshacl==0.30.1
+pyshacl==0.25.0
 SPARQLWrapper==2.0.0
 
 black==24.4.2

--- a/tests/kg/fixtures/bad_ear_missing_prov.jsonl
+++ b/tests/kg/fixtures/bad_ear_missing_prov.jsonl
@@ -1,0 +1,1 @@
+{"id": 1, "sha256": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc", "section": "738.1", "date": "2024-01-01"}

--- a/tests/kg/fixtures/bad_nsf_orphan_entity.jsonl
+++ b/tests/kg/fixtures/bad_nsf_orphan_entity.jsonl
@@ -1,0 +1,1 @@
+{"id": 1, "sha256": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd", "source_url": "https://example.org/nsf", "date": "2024-02-02", "entities": ["Widget Labs"]}

--- a/tests/kg/fixtures/ear_corpus.jsonl
+++ b/tests/kg/fixtures/ear_corpus.jsonl
@@ -1,0 +1,1 @@
+{"id": 1, "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "section": "738.1", "source_url": "https://example.org/ear", "date": "2024-01-01"}

--- a/tests/kg/fixtures/ear_small.jsonl
+++ b/tests/kg/fixtures/ear_small.jsonl
@@ -1,0 +1,1 @@
+{"id": 1, "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "section": "738.1", "source_url": "https://example.org/ear", "date": "2024-01-01"}

--- a/tests/kg/fixtures/nsf_corpus.jsonl
+++ b/tests/kg/fixtures/nsf_corpus.jsonl
@@ -1,0 +1,1 @@
+{"id": 1, "sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", "source_url": "https://example.org/nsf", "date": "2024-02-02", "entities": ["Acme Corp"]}

--- a/tests/kg/fixtures/nsf_small.jsonl
+++ b/tests/kg/fixtures/nsf_small.jsonl
@@ -1,0 +1,1 @@
+{"id": 1, "sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", "source_url": "https://example.org/nsf", "date": "2024-02-02", "entities": ["Acme Corp"]}

--- a/tests/kg/test_validate.py
+++ b/tests/kg/test_validate.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from subprocess import run
+
+from earCrawler.kg.emit_ear import emit_ear
+from earCrawler.kg.emit_nsf import emit_nsf
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def _copy(src: str, dst: Path) -> None:
+    dst.write_text((FIXTURES / src).read_text(), encoding="utf-8")
+
+
+def _run(args: list[str]):
+    return run([sys.executable, "-m", "cli.kg_validate", *args], capture_output=True, text=True)
+
+
+def test_validate_happy(tmp_path: Path) -> None:
+    in_dir = tmp_path / "in"
+    out_dir = tmp_path / "out"
+    in_dir.mkdir()
+    out_dir.mkdir()
+    _copy("ear_small.jsonl", in_dir / "ear_corpus.jsonl")
+    _copy("nsf_small.jsonl", in_dir / "nsf_corpus.jsonl")
+    emit_ear(in_dir, out_dir)
+    emit_nsf(in_dir, out_dir)
+    res = _run(["--glob", str(out_dir / "*.ttl")])
+    assert res.returncode == 0
+    assert "shacl" in res.stdout
+
+
+def test_validate_missing_provenance(tmp_path: Path) -> None:
+    in_dir = tmp_path / "in"
+    out_dir = tmp_path / "out"
+    in_dir.mkdir()
+    out_dir.mkdir()
+    _copy("bad_ear_missing_prov.jsonl", in_dir / "ear_corpus.jsonl")
+    emit_ear(in_dir, out_dir)
+    res = _run(["--ttl", str(out_dir / "ear.ttl")])
+    assert res.returncode == 1
+    assert "missing_provenance" in res.stdout
+    assert "False" in res.stdout
+
+
+def test_validate_orphan_entity(tmp_path: Path) -> None:
+    in_dir = tmp_path / "in"
+    out_dir = tmp_path / "out"
+    in_dir.mkdir()
+    out_dir.mkdir()
+    _copy("bad_nsf_orphan_entity.jsonl", in_dir / "nsf_corpus.jsonl")
+    emit_nsf(in_dir, out_dir)
+    ttl = out_dir / "nsf.ttl"
+    lines = [ln for ln in ttl.read_text().splitlines() if "ent:Entity" not in ln]
+    ttl.write_text("\n".join(lines) + "\n")
+    res = _run(["--ttl", str(ttl)])
+    assert res.returncode == 1
+    assert "entity_mentions_without_type" in res.stdout
+    res2 = _run(["--ttl", str(ttl), "--fail-on", "shacl-only"])
+    assert res2.returncode == 0


### PR DESCRIPTION
## Summary
- add SPARQL sanity checks and SHACL shapes with `kg-validate` CLI
- wire validation into CI and documentation; bump to v0.9.0
- include smoke test for emit/validate on Windows

## Testing
- `pytest -q --disable-warnings --maxfail=1`
- `python -m cli.kg_emit --sources ear --sources nsf --in tests/kg/fixtures --out tests/kg/artifacts`
- `python -m cli.kg_validate --glob "tests/kg/artifacts/*.ttl"`
- `python - <<'PY'
import glob
from rdflib import Graph
for p in glob.glob("tests/kg/artifacts/*.ttl"):
    Graph().parse(p, format="turtle")
    print("Parsed", p)
PY`


------
https://chatgpt.com/codex/tasks/task_e_689b7a6761d48325b82515eb526f5e2b