### PR TITLE
Load KG validation shapes via importlib resources

### DIFF
--- a/cli/kg_validate.py
+++ b/cli/kg_validate.py
@@ -11,18 +11,30 @@ from pathlib import Path
 from typing import List
 
 import click
+from importlib import resources
 
 from earCrawler.kg.validate import validate_files
 
 
 @click.command()
-@click.option("--ttl", "ttls", multiple=True, type=click.Path(path_type=Path), help="Path to TTL file.")
-@click.option("--glob", "glob_pattern", type=str, help="Glob pattern for TTL files.")
+@click.option(
+    "--ttl",
+    "ttls",
+    multiple=True,
+    type=click.Path(path_type=Path),
+    help="Path to TTL file.",
+)
+@click.option(
+    "--glob",
+    "glob_pattern",
+    type=str,
+    help="Glob pattern for TTL files.",
+)
 @click.option(
     "--shapes",
     type=click.Path(path_type=Path),
-    default=Path(__file__).resolve().parent.parent / "earCrawler" / "kg" / "shapes.ttl",
-    show_default=True,
+    default=None,
+    show_default=False,
     help="Path to SHACL shapes graph.",
 )
 @click.option(
@@ -32,14 +44,26 @@ from earCrawler.kg.validate import validate_files
     show_default=True,
     help="What violations trigger a non-zero exit code.",
 )
-def main(ttls: tuple[Path, ...], glob_pattern: str | None, shapes: Path, fail_on: str) -> None:
+def main(
+    ttls: tuple[Path, ...],
+    glob_pattern: str | None,
+    shapes: Path | None,
+    fail_on: str,
+) -> None:
     """Entry point for ``kg-validate`` CLI."""
 
     paths: List[str] = []
     if glob_pattern:
         paths.extend(glob(glob_pattern))
     paths.extend(str(p) for p in ttls)
-    exit_code = validate_files(paths, str(shapes), fail_on=fail_on)
+
+    if shapes is None:
+        with resources.as_file(
+            resources.files("earCrawler.kg").joinpath("shapes.ttl")
+        ) as default_shapes:
+            exit_code = validate_files(paths, default_shapes, fail_on=fail_on)
+    else:
+        exit_code = validate_files(paths, shapes, fail_on=fail_on)
     raise SystemExit(exit_code)
 
 

--- a/earCrawler/kg/validate.py
+++ b/earCrawler/kg/validate.py
@@ -30,12 +30,14 @@ def run_sparql_checks(graph: Graph) -> list[tuple[str, int]]:
     return results
 
 
-def run_shacl(graph: Graph, shapes_path: str) -> tuple[bool, Graph, str]:
+def run_shacl(
+    graph: Graph, shapes_path: str | Path
+) -> tuple[bool, Graph, str]:
     """Validate ``graph`` against ``shapes_path`` using ``pyshacl``."""
 
     conforms, results_graph, results_text = shacl_validate(
         graph,
-        shacl_graph=Graph().parse(shapes_path, format="turtle"),
+        shacl_graph=Graph().parse(str(shapes_path), format="turtle"),
         advanced=True,
         inference="rdfs",
         abort_on_first=False,
@@ -51,7 +53,12 @@ def _load_graph(path: Path) -> Graph:
     return g
 
 
-def validate_files(paths: Iterable[str], shapes_path: str, *, fail_on: str = "any") -> int:
+def validate_files(
+    paths: Iterable[str],
+    shapes_path: str | Path,
+    *,
+    fail_on: str = "any",
+) -> int:
     """Validate one or more Turtle files.
 
     Parameters
@@ -92,7 +99,7 @@ def validate_files(paths: Iterable[str], shapes_path: str, *, fail_on: str = "an
             return 2
         g = _load_graph(fp)
         sparql_counts = run_sparql_checks(g)
-        conforms, _, _ = run_shacl(g, str(shapes))
+        conforms, _, _ = run_shacl(g, shapes)
         row = [file, str(conforms)]
         for name, count in sparql_counts:
             row.append(str(count))
@@ -103,8 +110,13 @@ def validate_files(paths: Iterable[str], shapes_path: str, *, fail_on: str = "an
         rows.append(row)
 
     # Deterministic table output
-    col_widths = [max(len(h), *(len(r[i]) for r in rows)) for i, h in enumerate(headers)]
-    header_line = " ".join(h.ljust(col_widths[i]) for i, h in enumerate(headers))
+    col_widths = [
+        max(len(h), *(len(r[i]) for r in rows))
+        for i, h in enumerate(headers)
+    ]
+    header_line = " ".join(
+        h.ljust(col_widths[i]) for i, h in enumerate(headers)
+    )
     print(header_line)
     for r in rows:
         print(" ".join(r[i].ljust(col_widths[i]) for i in range(len(headers))))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,3 +18,9 @@ dependencies = [
 [project.scripts]
 earCrawler = "earCrawler.cli.__main__:main"
 kg-validate = "cli.kg_validate:main"
+
+[tool.setuptools]
+include-package-data = true
+
+[tool.setuptools.package-data]
+"earCrawler.kg" = ["shapes.ttl"]


### PR DESCRIPTION
## Summary
- resolve SHACL shapes path using `importlib.resources` so CLI works from any install layout
- allow KG validation utilities to accept `Path` objects
- package `earCrawler/kg/shapes.ttl` as package data

## Testing
- `flake8 cli/kg_validate.py earCrawler/kg/validate.py`
- `pytest tests/kg/test_validate.py::test_validate_happy -q`
- `python - <<'PY'
import subprocess, sys
res = subprocess.run([sys.executable,'-m','cli.kg_validate','--glob','tmp_cli_test/out/*.ttl'], capture_output=True, text=True)
print('returncode', res.returncode)
print(res.stdout)
PY`

------
https://chatgpt.com/codex/tasks/task_e_689b8760367c832596db811ef4d052f4