### PR TITLE
Load KG validation shapes via importlib resources

### DIFF
--- a/earCrawler/kg/validate.py
+++ b/earCrawler/kg/validate.py
@@ -30,12 +30,14 @@ def run_sparql_checks(graph: Graph) -> list[tuple[str, int]]:
     return results
 
 
-def run_shacl(graph: Graph, shapes_path: str) -> tuple[bool, Graph, str]:
+def run_shacl(
+    graph: Graph, shapes_path: str | Path
+) -> tuple[bool, Graph, str]:
     """Validate ``graph`` against ``shapes_path`` using ``pyshacl``."""
 
     conforms, results_graph, results_text = shacl_validate(
         graph,
-        shacl_graph=Graph().parse(shapes_path, format="turtle"),
+        shacl_graph=Graph().parse(str(shapes_path), format="turtle"),
         advanced=True,
         inference="rdfs",
         abort_on_first=False,
@@ -51,7 +53,12 @@ def _load_graph(path: Path) -> Graph:
     return g
 
 
-def validate_files(paths: Iterable[str], shapes_path: str, *, fail_on: str = "any") -> int:
+def validate_files(
+    paths: Iterable[str],
+    shapes_path: str | Path,
+    *,
+    fail_on: str = "any",
+) -> int:
     """Validate one or more Turtle files.
 
     Parameters
@@ -92,7 +99,7 @@ def validate_files(paths: Iterable[str], shapes_path: str, *, fail_on: str = "an
             return 2
         g = _load_graph(fp)
         sparql_counts = run_sparql_checks(g)
-        conforms, _, _ = run_shacl(g, str(shapes))
+        conforms, _, _ = run_shacl(g, shapes)
         row = [file, str(conforms)]
         for name, count in sparql_counts:
             row.append(str(count))
@@ -103,8 +110,13 @@ def validate_files(paths: Iterable[str], shapes_path: str, *, fail_on: str = "an
         rows.append(row)
 
     # Deterministic table output
-    col_widths = [max(len(h), *(len(r[i]) for r in rows)) for i, h in enumerate(headers)]
-    header_line = " ".join(h.ljust(col_widths[i]) for i, h in enumerate(headers))
+    col_widths = [
+        max(len(h), *(len(r[i]) for r in rows))
+        for i, h in enumerate(headers)
+    ]
+    header_line = " ".join(
+        h.ljust(col_widths[i]) for i, h in enumerate(headers)
+    )
     print(header_line)
     for r in rows:
         print(" ".join(r[i].ljust(col_widths[i]) for i in range(len(headers))))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,3 +18,9 @@ dependencies = [
 [project.scripts]
 earCrawler = "earCrawler.cli.__main__:main"
 kg-validate = "cli.kg_validate:main"
+
+[tool.setuptools]
+include-package-data = true
+
+[tool.setuptools.package-data]
+"earCrawler.kg" = ["shapes.ttl"]


### PR DESCRIPTION
## Summary
- resolve SHACL shapes path using `importlib.resources` so CLI works from any install layout
- allow KG validation utilities to accept `Path` objects and package `shapes.ttl`
- expand `--glob` patterns with `Path.glob` for reliable cross-platform validation

## Testing
- `flake8 cli/kg_validate.py earCrawler/kg/validate.py`
- `python -m pytest tests/kg/test_validate.py::test_validate_happy -q`
- `python -m pytest -q --disable-warnings --maxfail=1`
- `python - <<'PY'
import subprocess, sys, tempfile, shutil
from pathlib import Path
from earCrawler.kg.emit_ear import emit_ear
from earCrawler.kg.emit_nsf import emit_nsf

tmpdir = Path('tmp_cli_test')
shutil.rmtree(tmpdir, ignore_errors=True)
ind = tmpdir/'in'
outd = tmpdir/'out'
ind.mkdir(parents=True)
outd.mkdir(parents=True)
fixtures = Path('tests/kg/fixtures')
(ind/'ear_corpus.jsonl').write_text((fixtures/'ear_small.jsonl').read_text())
(ind/'nsf_corpus.jsonl').write_text((fixtures/'nsf_small.jsonl').read_text())
emit_ear(ind, outd)
emit_nsf(ind, outd)
res = subprocess.run([sys.executable, '-m', 'cli.kg_validate', '--glob', str(outd/'*.ttl')], capture_output=True, text=True)
print('returncode', res.returncode)
print(res.stdout)
PY`

------
https://chatgpt.com/codex/tasks/task_e_689b8760367c832596db811ef4d052f4