### PR TITLE
B.6 — Fuseki/Jena round-trip + SPARQL snapshots (Windows)

### DIFF
--- a/.github/workflows/kg-ci.yml
+++ b/.github/workflows/kg-ci.yml
@@ -1,0 +1,41 @@
+name: kg-ci
+
+on:
+  push:
+    paths:
+      - 'kg/**'
+      - '.github/workflows/kg-ci.yml'
+  pull_request:
+    paths:
+      - 'kg/**'
+      - '.github/workflows/kg-ci.yml'
+
+jobs:
+  roundtrip:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+      - name: Install Apache Jena and Fuseki
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force -Path tools | Out-Null
+          Invoke-WebRequest -Uri https://dlcdn.apache.org/jena/binaries/apache-jena-5.3.0.zip -OutFile jena.zip
+          Expand-Archive jena.zip -DestinationPath tools
+          Move-Item tools/apache-jena-5.3.0 tools/jena
+          Invoke-WebRequest -Uri https://dlcdn.apache.org/jena/binaries/apache-jena-fuseki-5.3.0.zip -OutFile fuseki.zip
+          Expand-Archive fuseki.zip -DestinationPath tools
+          Move-Item tools/apache-jena-fuseki-5.3.0 tools/fuseki
+      - name: Run round-trip and query snapshots
+        shell: pwsh
+        run: kg/scripts/ci-roundtrip.ps1
+      - name: Upload SPARQL snapshots
+        if: ${{ success() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: sparql-snapshots
+          path: kg/snapshots/*.srj

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,3 +63,5 @@
 - Add Mistral-7B QLoRA instruction-tuned agent with LoRA adapters. [#VERSION]
 - Add end-to-end benchmark script integrating LoRA and QLoRA components. [#VERSION]
 - Finalize production Docker images and monitoring for LoRA/QLoRA pipeline. [#VERSION]
+
+v0.6.0 – B.6: RIOT validation, TDB2 round-trip with isomorphism fallback, deterministic SPARQL snapshots, Fuseki smoke query, Windows CI, and pytest smoke tests.

--- a/README.md
+++ b/README.md
@@ -358,3 +358,14 @@ discuss what you would like to change.
 
 ## License
 This project is licensed under the MIT License.
+
+## B.6 (Windows)
+The `kg/scripts/ci-roundtrip.ps1` script validates Turtle files with RIOT,
+round-trips them through a fresh TDB2 store, snapshots deterministic SPARQL
+queries to `kg/snapshots/*.srj`, and performs a Fuseki smoke query.
+
+Run locally:
+
+```powershell
+pwsh kg/scripts/ci-roundtrip.ps1
+```

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -108,3 +108,12 @@ Stop the server with `Ctrl+C` in the console. For programmatic use, the
 | --- | --- |
 | missing_provenance | Ensure the source JSONL has `source_url`, `prov:wasDerivedFrom`, and `date` fields. |
 | entity_mentions_without_type | Regenerate TTL ensuring each entity node is typed `ent:Entity`. |
+
+## B.6 Round-trip CI
+- `.github/workflows/kg-ci.yml` runs `kg/scripts/ci-roundtrip.ps1` on Windows to
+  validate TTL, round-trip through TDB2, capture SPARQL snapshots, and smoke-test
+  Fuseki.
+- If a snapshot diff fails, inspect the `.srj.actual` file, update the expected
+  snapshot under `kg/snapshots`, and re-run the script.
+- The isomorphism fallback is implemented in `kg/tools/GraphIsoCheck.java` and
+  is compiled on-the-fly when a textual diff is detected.

--- a/api_clients/federalregister_client.py
+++ b/api_clients/federalregister_client.py
@@ -95,3 +95,8 @@ class FederalRegisterClient:
                 "Invalid JSON structure from Federal Register"
             )
         return data
+
+    def get_ear_text(self, citation: str) -> str:
+        """Retrieve the EAR body HTML for a Federal Register citation."""
+        data = self.get_document(citation)
+        return data.get("body_html", "")

--- a/api_clients/tradegov_client.py
+++ b/api_clients/tradegov_client.py
@@ -118,5 +118,9 @@ class TradeGovEntityClient:
             page = next_page
 
 
+    def lookup_entity(self, query: str) -> dict:
+        """Return the first entity matching ``query`` or an empty dict if none."""
+        return next(self.search_entities(query, page_size=1), {})
+
 # Backwards compatibility alias
 TradeGovClient = TradeGovEntityClient

--- a/kg/queries/classes_count.rq
+++ b/kg/queries/classes_count.rq
@@ -1,0 +1,5 @@
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+SELECT (COUNT(?cls) AS ?count)
+WHERE {
+  ?cls a owl:Class .
+}

--- a/kg/queries/smoke.rq
+++ b/kg/queries/smoke.rq
@@ -1,0 +1,1 @@
+SELECT ?s ?p ?o WHERE { ?s ?p ?o } LIMIT 1

--- a/kg/scripts/ci-roundtrip.ps1
+++ b/kg/scripts/ci-roundtrip.ps1
@@ -1,0 +1,89 @@
+param()
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$repoRoot = Resolve-Path (Join-Path $PSScriptRoot '..')
+$jena = Join-Path $repoRoot 'tools/jena'
+$fuseki = Join-Path $repoRoot 'tools/fuseki'
+$kgDir = Join-Path $repoRoot 'kg'
+$targetDir = Join-Path $kgDir 'target'
+$tdbDir = Join-Path $targetDir 'tdb2'
+
+if (Test-Path $targetDir) { Remove-Item $targetDir -Recurse -Force }
+New-Item -ItemType Directory -Path $tdbDir | Out-Null
+
+$ttlFiles = Get-ChildItem -Path (Join-Path $kgDir '*.ttl')
+foreach ($ttl in $ttlFiles) {
+    & (Join-Path $jena 'bin/riot.bat') --validate $ttl.FullName
+    if ($LASTEXITCODE -ne 0) { throw "RIOT validation failed for $($ttl.Name)" }
+}
+
+foreach ($ttl in $ttlFiles) {
+    & (Join-Path $jena 'bin/tdb2_tdbloader.bat') --loc $tdbDir $ttl.FullName
+    if ($LASTEXITCODE -ne 0) { throw "TDB2 load failed for $($ttl.Name)" }
+}
+
+$dumpNq = Join-Path $targetDir 'dump.nq'
+& (Join-Path $jena 'bin/tdb2_tdbdump.bat') --loc $tdbDir | Out-File -FilePath $dumpNq -Encoding utf8
+if ($LASTEXITCODE -ne 0) { throw 'TDB2 dump failed' }
+
+$origNq = Join-Path $targetDir 'orig.nq'
+foreach ($ttl in $ttlFiles) {
+    & (Join-Path $jena 'bin/riot.bat') --output=NQUADS $ttl.FullName | Out-File -FilePath $origNq -Encoding utf8 -Append
+    if ($LASTEXITCODE -ne 0) { throw "Canonicalization failed for $($ttl.Name)" }
+}
+
+$dumpSorted = Join-Path $targetDir 'dump.sorted.nq'
+$origSorted = Join-Path $targetDir 'orig.sorted.nq'
+Get-Content $dumpNq | Sort-Object | Set-Content $dumpSorted
+Get-Content $origNq | Sort-Object | Set-Content $origSorted
+
+$diff = Compare-Object (Get-Content $origSorted) (Get-Content $dumpSorted)
+if ($diff) {
+    $javaSrc = Join-Path $kgDir 'tools/GraphIsoCheck.java'
+    $classDir = Join-Path $targetDir 'classes'
+    New-Item -ItemType Directory -Path $classDir | Out-Null
+    $jenaLib = Join-Path $jena 'lib/*'
+    & javac -cp $jenaLib -d $classDir $javaSrc
+    if ($LASTEXITCODE -ne 0) { throw 'javac failed' }
+    $cp = "$classDir;" + $jenaLib
+    & java -cp $cp GraphIsoCheck $origNq $dumpNq
+    if ($LASTEXITCODE -ne 0) { throw 'Graph isomorphism check failed' }
+}
+
+$queryDir = Join-Path $kgDir 'queries'
+$snapDir = Join-Path $kgDir 'snapshots'
+$queries = Get-ChildItem -Path $queryDir -Filter *.rq
+foreach ($q in $queries) {
+    $name = [System.IO.Path]::GetFileNameWithoutExtension($q.Name)
+    $actual = Join-Path $snapDir ($name + '.srj.actual')
+    & (Join-Path $jena 'bin/tdb2_tdbquery.bat') --loc $tdbDir --results=JSON $q.FullName | Out-File -FilePath $actual -Encoding utf8
+    if ($LASTEXITCODE -ne 0) { throw "Query failed for $($q.Name)" }
+    $snap = Join-Path $snapDir ($name + '.srj')
+    if (Test-Path $snap) {
+        $cmp = Compare-Object (Get-Content $snap) (Get-Content $actual)
+        if ($cmp) {
+            Write-Error "Snapshot mismatch for $name"
+            exit 1
+        } else {
+            Remove-Item $actual
+        }
+    } else {
+        Move-Item $actual $snap
+    }
+}
+
+$smokeQuery = Join-Path $queryDir 'smoke.rq'
+$fusekiProc = Start-Process -FilePath (Join-Path $fuseki 'fuseki-server.bat') -ArgumentList @('--loc', $tdbDir, '/ds') -PassThru -WindowStyle Hidden
+try {
+    Start-Sleep -Seconds 5
+    & (Join-Path $jena 'bin/arq.bat') --query $smokeQuery --service http://localhost:3030/ds/sparql | Out-Null
+    if ($LASTEXITCODE -ne 0) { throw 'Remote query failed' }
+} finally {
+    if ($fusekiProc -and !$fusekiProc.HasExited) {
+        Stop-Process -Id $fusekiProc.Id -Force
+    }
+}
+
+Write-Host 'Round-trip and snapshots succeeded'
+exit 0

--- a/kg/tools/GraphIsoCheck.java
+++ b/kg/tools/GraphIsoCheck.java
@@ -1,0 +1,22 @@
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.riot.RDFDataMgr;
+
+public class GraphIsoCheck {
+    public static void main(String[] args) {
+        if (args.length != 2) {
+            System.err.println("Usage: GraphIsoCheck <file1> <file2>");
+            System.exit(2);
+        }
+        Model m1 = ModelFactory.createDefaultModel();
+        Model m2 = ModelFactory.createDefaultModel();
+        RDFDataMgr.read(m1, args[0]);
+        RDFDataMgr.read(m2, args[1]);
+        if (m1.isIsomorphicWith(m2)) {
+            System.exit(0);
+        } else {
+            System.err.println("Graphs not isomorphic");
+            System.exit(1);
+        }
+    }
+}

--- a/tests/test_api_clients_stubs.py
+++ b/tests/test_api_clients_stubs.py
@@ -1,0 +1,18 @@
+import pathlib, sys
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+import inspect
+
+from api_clients.tradegov_client import TradeGovClient
+from api_clients.federalregister_client import FederalRegisterClient
+
+
+def test_tradegov_client_has_lookup_entity():
+    assert hasattr(TradeGovClient, 'lookup_entity')
+    sig = inspect.signature(TradeGovClient.lookup_entity)
+    assert 'query' in sig.parameters
+
+
+def test_federalregister_client_has_get_ear_text():
+    assert hasattr(FederalRegisterClient, 'get_ear_text')
+    sig = inspect.signature(FederalRegisterClient.get_ear_text)
+    assert 'citation' in sig.parameters

--- a/tests/test_roundtrip_ci.py
+++ b/tests/test_roundtrip_ci.py
@@ -1,0 +1,29 @@
+import pathlib
+import subprocess
+import sys
+
+import pytest
+
+SCRIPT = pathlib.Path(__file__).resolve().parents[1] / 'kg' / 'scripts' / 'ci-roundtrip.ps1'
+JENA_DIR = pathlib.Path('tools') / 'jena'
+FUSEKI_DIR = pathlib.Path('tools') / 'fuseki'
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows-only")
+def test_ci_roundtrip_script_exists():
+    assert SCRIPT.exists()
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows-only")
+def test_ci_roundtrip_runs_if_tools_present():
+    if not (JENA_DIR.exists() and FUSEKI_DIR.exists()):
+        pytest.skip("Jena or Fuseki tools missing")
+    result = subprocess.run(["pwsh", str(SCRIPT)], capture_output=True, text=True)
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows-only")
+def test_snapshot_files_exist_after_ci():
+    snap_dir = pathlib.Path('kg') / 'snapshots'
+    assert snap_dir.exists()
+    list(snap_dir.glob('*.srj'))  # should not raise


### PR DESCRIPTION
## Summary
- add PowerShell round-trip script that validates TTL, snapshots deterministic SPARQL queries, and smoke tests Fuseki
- wire up Windows GitHub Actions workflow to run the round-trip and publish `.srj` snapshots
- provide API client stubs and pytest smoke tests

## Testing
- `pytest tests/test_api_clients_stubs.py tests/test_roundtrip_ci.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68ae0a82f9408325842dfe9ae46c7064