### PR TITLE
B.7 — SHACL/OWL reasoner smoke tests on TDB2 (Windows)

### DIFF
--- a/.github/workflows/kg-ci.yml
+++ b/.github/workflows/kg-ci.yml
@@ -39,3 +39,33 @@ jobs:
         with:
           name: sparql-snapshots
           path: kg/snapshots/*.srj
+  shacl-owl-smoke:
+    needs: roundtrip
+    if: always()
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+      - name: Install Apache Jena and Fuseki
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force -Path tools | Out-Null
+          Invoke-WebRequest -Uri https://dlcdn.apache.org/jena/binaries/apache-jena-5.3.0.zip -OutFile jena.zip
+          Expand-Archive jena.zip -DestinationPath tools
+          Move-Item tools/apache-jena-5.3.0 tools/jena
+          Invoke-WebRequest -Uri https://dlcdn.apache.org/jena/binaries/apache-jena-fuseki-5.3.0.zip -OutFile fuseki.zip
+          Expand-Archive fuseki.zip -DestinationPath tools
+          Move-Item tools/apache-jena-fuseki-5.3.0 tools/fuseki
+      - name: Run SHACL and OWL smoke tests
+        shell: pwsh
+        run: kg/scripts/ci-shacl-owl.ps1
+      - name: Upload SHACL/OWL reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: shacl-owl-reports
+          path: kg/reports/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 __pycache__/
-tools/
+/tools/
 !tools/.gitkeep
+kg/reports/
+kg/shapes.ttl

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,3 +65,4 @@
 - Finalize production Docker images and monitoring for LoRA/QLoRA pipeline. [#VERSION]
 
 v0.6.0 – B.6: RIOT validation, TDB2 round-trip with isomorphism fallback, deterministic SPARQL snapshots, Fuseki smoke query, Windows CI, and pytest smoke tests.
+v0.7.0 – B.7: SHACL validation, OWL reasoner smoke checks, Windows CI job, and pytest coverage.

--- a/README.md
+++ b/README.md
@@ -369,3 +369,19 @@ Run locally:
 ```powershell
 pwsh kg/scripts/ci-roundtrip.ps1
 ```
+
+## B.7 SHACL/OWL smoke (Windows)
+The `kg/scripts/ci-shacl-owl.ps1` script validates ontology TTL files against SHACL shapes and runs lightweight OWL reasoner ASK checks.
+
+Run locally:
+
+```powershell
+pwsh kg/scripts/ci-shacl-owl.ps1
+```
+
+Artifacts are written to `kg/reports/`:
+- `shacl-report.ttl` and `shacl-report.json`
+- `shacl-conforms.txt` with `true` or `false`
+- `owl-smoke.json` summarizing three ASK checks
+
+Failures indicate SHACL non-conformance or missing OWL entailments. Review the report files to diagnose issues.

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -117,3 +117,9 @@ Stop the server with `Ctrl+C` in the console. For programmatic use, the
   snapshot under `kg/snapshots`, and re-run the script.
 - The isomorphism fallback is implemented in `kg/tools/GraphIsoCheck.java` and
   is compiled on-the-fly when a textual diff is detected.
+## B.7 SHACL/OWL smoke
+- `kg/scripts/ci-shacl-owl.ps1` runs SHACL validation against `kg/shapes.ttl` and executes three OWL reasoner ASK queries.
+- Reports are written to `kg/reports/`.
+- `shacl-conforms.txt` of `false` indicates shape violations; inspect `shacl-report.ttl` or `.json`.
+- Failed OWL checks appear in `owl-smoke.json` with `passed: false`.
+- CI job `shacl-owl-smoke` runs after the round-trip step and uploads reports even on failure.

--- a/kg/queries/reasoner_ask_domain_range.rq
+++ b/kg/queries/reasoner_ask_domain_range.rq
@@ -1,0 +1,5 @@
+PREFIX ex: <http://example.com/reasoner-smoke#>
+ASK {
+  ex:subject a ex:DomainClass .
+  ex:object a ex:RangeClass .
+}

--- a/kg/queries/reasoner_ask_equivalence.rq
+++ b/kg/queries/reasoner_ask_equivalence.rq
@@ -1,0 +1,2 @@
+PREFIX ex: <http://example.com/reasoner-smoke#>
+ASK { ex:eqInstance a ex:ClassB . }

--- a/kg/queries/reasoner_ask_subclass.rq
+++ b/kg/queries/reasoner_ask_subclass.rq
@@ -1,0 +1,2 @@
+PREFIX ex: <http://example.com/reasoner-smoke#>
+ASK { ex:instance1 a ex:Parent . }

--- a/kg/scripts/ci-shacl-owl.ps1
+++ b/kg/scripts/ci-shacl-owl.ps1
@@ -1,0 +1,85 @@
+param()
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$repoRoot = Resolve-Path (Join-Path $PSScriptRoot '..')
+$jena = Join-Path $repoRoot 'tools/jena'
+$fuseki = Join-Path $repoRoot 'tools/fuseki'
+if (-not (Test-Path $jena)) { throw 'Jena not found at tools/jena' }
+if (-not (Test-Path $fuseki)) { throw 'Fuseki not found at tools/fuseki' }
+
+$kgDir = Join-Path $repoRoot 'kg'
+$reportsDir = Join-Path $kgDir 'reports'
+New-Item -ItemType Directory -Force -Path $reportsDir | Out-Null
+
+# Ensure shapes.ttl
+$shapeDest = Join-Path $kgDir 'shapes.ttl'
+$shapesCopied = $false
+if (-not (Test-Path $shapeDest)) {
+    $shapeSrc = Join-Path $repoRoot 'earCrawler/kg/shapes.ttl'
+    Copy-Item $shapeSrc $shapeDest
+    $shapesCopied = $true
+}
+
+# Collect data TTLs (excluding shapes)
+$ttlFiles = Get-ChildItem -Path $kgDir -Filter *.ttl | Where-Object { $_.Name -ne 'shapes.ttl' }
+
+# --- SHACL validation ---
+$shacl = Join-Path $jena 'bin/shacl.bat'
+$dataArgs = @()
+foreach ($ttl in $ttlFiles) { $dataArgs += @('--data', $ttl.FullName) }
+$shaclTtl = Join-Path $reportsDir 'shacl-report.ttl'
+$shaclJson = Join-Path $reportsDir 'shacl-report.json'
+& $shacl validate --shapes $shapeDest @dataArgs --report $shaclTtl --report-json $shaclJson | Out-Null
+$shaclExit = $LASTEXITCODE
+$shaclInfo = Get-Content -Raw $shaclJson | ConvertFrom-Json
+$conf = $shaclInfo.conforms
+Set-Content -Path (Join-Path $reportsDir 'shacl-conforms.txt') -Value ($conf.ToString().ToLowerInvariant())
+if ($shaclExit -ne 0 -or -not $conf) {
+    if ($shapesCopied) { Remove-Item $shapeDest -Force }
+    Write-Error 'SHACL validation failed'
+    exit 1
+}
+
+# --- OWL smoke tests ---
+$javaSrc = Join-Path $kgDir 'tools/OwlAsk.java'
+$classDir = Join-Path $kgDir 'target/owlask'
+if (Test-Path $classDir) { Remove-Item $classDir -Recurse -Force }
+New-Item -ItemType Directory -Force -Path $classDir | Out-Null
+$jenaLib = Join-Path $jena 'lib/*'
+& javac -cp $jenaLib -d $classDir $javaSrc
+if ($LASTEXITCODE -ne 0) {
+    if ($shapesCopied) { Remove-Item $shapeDest -Force }
+    throw 'javac failed'
+}
+$cp = "$classDir;$jenaLib"
+
+$fixture = Join-Path $kgDir 'testdata/reasoner_smoke.ttl'
+$dataFiles = $ttlFiles.FullName + $fixture
+
+$queries = @(
+    @{ name = 'subclass'; file = Join-Path $kgDir 'queries/reasoner_ask_subclass.rq'; explanation = 'Subclass inference via rdfs:subClassOf'; },
+    @{ name = 'domain-range'; file = Join-Path $kgDir 'queries/reasoner_ask_domain_range.rq'; explanation = 'Domain and range infer types'; },
+    @{ name = 'equivalence'; file = Join-Path $kgDir 'queries/reasoner_ask_equivalence.rq'; explanation = 'Equivalent classes propagate type'; }
+)
+
+$results = @()
+$fail = $false
+foreach ($q in $queries) {
+    & java -cp $cp OwlAsk $q.file @dataFiles | Out-Null
+    $passed = $LASTEXITCODE -eq 0
+    $results += [pscustomobject]@{ name = $q.name; passed = $passed; explanation = $q.explanation }
+    if (-not $passed) { $fail = $true }
+}
+
+$results | ConvertTo-Json | Set-Content (Join-Path $reportsDir 'owl-smoke.json')
+
+if ($shapesCopied) { Remove-Item $shapeDest -Force }
+
+if ($fail) {
+    Write-Error 'OWL smoke checks failed'
+    exit 1
+}
+
+Write-Host 'SHACL validation and OWL smoke checks succeeded'
+exit 0

--- a/kg/testdata/reasoner_smoke.ttl
+++ b/kg/testdata/reasoner_smoke.ttl
@@ -1,0 +1,13 @@
+@prefix ex: <http://example.com/reasoner-smoke#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+ex:Child rdfs:subClassOf ex:Parent .
+ex:instance1 a ex:Child .
+
+ex:prop rdfs:domain ex:DomainClass ;
+        rdfs:range ex:RangeClass .
+ex:subject ex:prop ex:object .
+
+ex:ClassA owl:equivalentClass ex:ClassB .
+ex:eqInstance a ex:ClassA .

--- a/kg/tools/OwlAsk.java
+++ b/kg/tools/OwlAsk.java
@@ -1,0 +1,35 @@
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+import org.apache.jena.ontology.OntModel;
+import org.apache.jena.ontology.OntModelSpec;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.query.*;
+
+public class OwlAsk {
+    public static void main(String[] args) throws Exception {
+        if (args.length < 2) {
+            System.err.println("Usage: OwlAsk query.rq data1.ttl [data2.ttl ...]");
+            System.exit(1);
+        }
+        String queryFile = args[0];
+        Model base = ModelFactory.createDefaultModel();
+        for (int i = 1; i < args.length; i++) {
+            try (InputStream in = new FileInputStream(args[i])) {
+                base.read(in, null, "TTL");
+            }
+        }
+        OntModel model = ModelFactory.createOntologyModel(OntModelSpec.OWL_MEM_MICRO_RULE_INF, base);
+        String queryString = new String(Files.readAllBytes(Paths.get(queryFile)), java.nio.charset.StandardCharsets.UTF_8);
+        Query query = QueryFactory.create(queryString);
+        try (QueryExecution qexec = QueryExecutionFactory.create(query, model)) {
+            boolean result = qexec.execAsk();
+            String out = "{\"query\":\"" + queryFile.replace("\\", "\\\\").replace("\"", "\\\"") + "\",\"result\":" + result + "}";
+            System.out.println(out);
+            System.exit(result ? 0 : 1);
+        }
+    }
+}

--- a/tests/test_shacl_owl_smoke.py
+++ b/tests/test_shacl_owl_smoke.py
@@ -1,0 +1,35 @@
+import json
+import pathlib
+import subprocess
+import sys
+import shutil
+
+import pytest
+
+SCRIPT = pathlib.Path('kg/scripts/ci-shacl-owl.ps1')
+JENA_DIR = pathlib.Path('tools') / 'jena'
+FUSEKI_DIR = pathlib.Path('tools') / 'fuseki'
+REPORTS_DIR = pathlib.Path('kg') / 'reports'
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows-only")
+def test_ci_shacl_owl_script_exists():
+    assert SCRIPT.exists()
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows-only")
+def test_shacl_report_artifacts_when_tools_present():
+    if not (JENA_DIR.exists() and FUSEKI_DIR.exists()):
+        pytest.skip("Jena or Fuseki tools missing")
+    if REPORTS_DIR.exists():
+        shutil.rmtree(REPORTS_DIR)
+    result = subprocess.run(["pwsh", str(SCRIPT)], capture_output=True, text=True)
+    assert result.returncode == 0, result.stdout + result.stderr
+    conforms_path = REPORTS_DIR / "shacl-conforms.txt"
+    assert conforms_path.exists()
+    assert conforms_path.read_text().strip() == "true"
+    owl_json = REPORTS_DIR / "owl-smoke.json"
+    assert owl_json.exists()
+    data = json.loads(owl_json.read_text())
+    assert len(data) == 3
+    assert all(item["passed"] for item in data)


### PR DESCRIPTION
## Summary
- Validate KG TTLs against SHACL shapes and run OWL ASK checks using a Windows PowerShell script
- Add OWL reasoner fixture triples, ASK queries, and Java helper to execute queries
- Extend Windows CI with SHACL/OWL smoke job and cover with pytest

## Testing
- `pytest tests/test_shacl_owl_smoke.py -vv` *(skipped: Windows-only)*

------
https://chatgpt.com/codex/tasks/task_e_68ae10edb5e48325b044c0a2ed39ecb5