### PR TITLE
B.8 — Fuseki assembler–based OWL/RDFS inference service + CI smoke (Windows)

### DIFF
--- a/.github/workflows/kg-ci.yml
+++ b/.github/workflows/kg-ci.yml
@@ -93,3 +93,48 @@ jobs:
         with:
           name: shacl-owl-reports
           path: kg/reports/*
+  inference-smoke:
+    needs: [roundtrip, shacl-owl-smoke]
+    if: always()
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Guard versions
+        shell: pwsh
+        run: python scripts/check_versions.py
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+      - name: Install Apache Jena and Fuseki
+        shell: pwsh
+        run: |
+          $v = Get-Content tools/versions.json | ConvertFrom-Json
+          $jenaVer = $v.jena
+          $fusekiVer = $v.fuseki
+          New-Item -ItemType Directory -Force -Path tools | Out-Null
+          $jenaArchive = "https://archive.apache.org/dist/jena/binaries/apache-jena-$jenaVer.zip"
+          $jenaMirror = "https://downloads.apache.org/jena/binaries/apache-jena-$jenaVer.zip"
+          try { Invoke-WebRequest -Uri $jenaArchive -OutFile jena.zip -ErrorAction Stop } catch { Invoke-WebRequest -Uri $jenaMirror -OutFile jena.zip }
+          Expand-Archive jena.zip -DestinationPath tools
+          Move-Item tools/apache-jena-$jenaVer tools/jena
+          $fusekiArchive = "https://archive.apache.org/dist/jena/binaries/apache-jena-fuseki-$fusekiVer.zip"
+          $fusekiMirror = "https://downloads.apache.org/jena/binaries/apache-jena-fuseki-$fusekiVer.zip"
+          try { Invoke-WebRequest -Uri $fusekiArchive -OutFile fuseki.zip -ErrorAction Stop } catch { Invoke-WebRequest -Uri $fusekiMirror -OutFile fuseki.zip }
+          Expand-Archive fuseki.zip -DestinationPath tools
+          Move-Item tools/apache-jena-fuseki-$fusekiVer tools/fuseki
+          Test-Path (Join-Path tools/jena 'bat/riot.bat') | Out-Null
+          Test-Path (Join-Path tools/jena 'bat/arq.bat') | Out-Null
+      - name: Run inference smoke (RDFS)
+        shell: pwsh
+        run: kg/scripts/ci-inference-smoke.ps1 -Mode rdfs
+      - name: Run inference smoke (OWL Mini)
+        shell: pwsh
+        run: kg/scripts/ci-inference-smoke.ps1 -Mode owlmini
+      - name: Upload inference reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: inference-reports
+          path: kg/reports/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,3 +68,4 @@
 
 v0.6.0 – B.6: RIOT validation, TDB2 round-trip with isomorphism fallback, deterministic SPARQL snapshots, Fuseki smoke query, Windows CI, and pytest smoke tests.
 v0.7.0 – B.7: SHACL validation, OWL reasoner smoke checks, Windows CI job, and pytest coverage.
+v0.8.0 – B.8: Fuseki assembler inference service, RDFS/OWL Mini modes, Windows CI smoke, and tests.

--- a/README.md
+++ b/README.md
@@ -396,3 +396,26 @@ Artifacts are written to `kg/reports/`:
 - `owl-smoke.json` summarizing three ASK checks
 
 Failures indicate SHACL non-conformance or missing OWL entailments. Review the report files to diagnose issues.
+
+## B.8 Inference service (Windows)
+Use the assembler configs under `kg/assembler/` to expose an inference-enabled dataset at `/ds-inf`.
+
+```powershell
+fuseki-server.bat --config kg/assembler/tdb2-inference-rdfs.ttl
+# or
+fuseki-server.bat --config kg/assembler/tdb2-inference-owlmini.ttl
+```
+
+Run the smoke script to validate remote ASK queries and capture a SELECT report:
+
+```powershell
+pwsh kg/scripts/ci-inference-smoke.ps1 -Mode rdfs
+pwsh kg/scripts/ci-inference-smoke.ps1 -Mode owlmini
+```
+
+Artifacts are written to `kg/reports/`:
+- `inference-<mode>.json` summary of ASK checks
+- `inference-<mode>.txt` one-line status
+- `inference-<mode>-select.srj` SELECT snapshot
+
+All ASK checks must pass for the script to exit 0. Use the `.srj` file for manual inspection of inferred bindings.

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -131,3 +131,27 @@ Stop the server with `Ctrl+C` in the console. For programmatic use, the
 - `shacl-conforms.txt` of `false` indicates shape violations; inspect `shacl-report.ttl` or `.json`.
 - Failed OWL checks appear in `owl-smoke.json` with `passed: false`.
 - CI job `shacl-owl-smoke` runs after the round-trip step and uploads reports even on failure.
+
+## B.8 Inference service
+### Assembler anatomy
+`kg/assembler/tdb2-inference-*.ttl` wraps a TDB2 dataset under `kg/target/tdb2` with a `ja:InfModel` and publishes a Fuseki service `/ds-inf` with a `/sparql` endpoint. The RDFS config uses `RDFSRuleReasonerFactory` while the OWL Mini variant uses `OWLMiniReasonerFactory`.
+
+### Switching modes
+Start Fuseki with the desired assembler:
+
+```powershell
+fuseki-server.bat --config kg/assembler/tdb2-inference-rdfs.ttl   # RDFS
+fuseki-server.bat --config kg/assembler/tdb2-inference-owlmini.ttl # OWL Mini
+```
+
+Run the smoke script to load TTLs, boot the server, and execute remote queries:
+
+```powershell
+pwsh kg/scripts/ci-inference-smoke.ps1 -Mode rdfs
+pwsh kg/scripts/ci-inference-smoke.ps1 -Mode owlmini
+```
+
+### Troubleshooting
+- **Server won't start:** ensure `tools/jena` and `tools/fuseki` exist and no other process is using port 3030.
+- **ASK check fails:** verify all TTL files (excluding `shapes.ttl`) and the `testdata/reasoner_smoke.ttl` fixture loaded into `kg/target/tdb2`.
+- **Empty SELECT report:** check that inference mode matches expectations and queries reference the correct namespace.

--- a/kg/assembler/tdb2-inference-owlmini.ttl
+++ b/kg/assembler/tdb2-inference-owlmini.ttl
@@ -1,0 +1,23 @@
+@prefix : <#> .
+@prefix tdb2: <http://jena.apache.org/2016/tdb#> .
+@prefix ja: <http://jena.hpl.hp.com/2005/11/Assembler#> .
+@prefix fuseki: <http://jena.apache.org/fuseki#> .
+
+[] a fuseki:Server ;
+   fuseki:services ( <#service> ) .
+
+<#dataset> a tdb2:DatasetTDB2 ;
+    tdb2:location "kg/target/tdb2" .
+
+<#owlminiReasoner> a ja:ReasonerFactory ;
+    ja:reasonerClass "org.apache.jena.reasoner.rulesys.OWLMiniReasonerFactory" .
+
+<#inf> a ja:InfModel ;
+    ja:baseDataset <#dataset> ;
+    ja:reasoner <#owlminiReasoner> .
+
+<#service> a fuseki:Service ;
+    fuseki:name "ds-inf" ;
+    fuseki:serviceQuery "sparql" ;
+    fuseki:dataset <#inf> ;
+    fuseki:allowUpdate false .

--- a/kg/assembler/tdb2-inference-rdfs.ttl
+++ b/kg/assembler/tdb2-inference-rdfs.ttl
@@ -1,0 +1,23 @@
+@prefix : <#> .
+@prefix tdb2: <http://jena.apache.org/2016/tdb#> .
+@prefix ja: <http://jena.hpl.hp.com/2005/11/Assembler#> .
+@prefix fuseki: <http://jena.apache.org/fuseki#> .
+
+[] a fuseki:Server ;
+   fuseki:services ( <#service> ) .
+
+<#dataset> a tdb2:DatasetTDB2 ;
+    tdb2:location "kg/target/tdb2" .
+
+<#rdfsReasoner> a ja:ReasonerFactory ;
+    ja:reasonerClass "org.apache.jena.reasoner.rulesys.RDFSRuleReasonerFactory" .
+
+<#inf> a ja:InfModel ;
+    ja:baseDataset <#dataset> ;
+    ja:reasoner <#rdfsReasoner> .
+
+<#service> a fuseki:Service ;
+    fuseki:name "ds-inf" ;
+    fuseki:serviceQuery "sparql" ;
+    fuseki:dataset <#inf> ;
+    fuseki:allowUpdate false .

--- a/kg/queries/infer_domain_range_ask.rq
+++ b/kg/queries/infer_domain_range_ask.rq
@@ -1,0 +1,5 @@
+PREFIX ex: <http://example.com/reasoner-smoke#>
+ASK {
+  ex:subject a ex:DomainClass .
+  ex:object a ex:RangeClass .
+}

--- a/kg/queries/infer_equivalence_ask.rq
+++ b/kg/queries/infer_equivalence_ask.rq
@@ -1,0 +1,2 @@
+PREFIX ex: <http://example.com/reasoner-smoke#>
+ASK { ex:eqInstance a ex:ClassB . }

--- a/kg/queries/infer_report_select.rq
+++ b/kg/queries/infer_report_select.rq
@@ -1,0 +1,3 @@
+PREFIX ex: <http://example.com/reasoner-smoke#>
+SELECT ?s WHERE { ?s a ex:Parent . }
+ORDER BY ?s

--- a/kg/queries/infer_subclass_ask.rq
+++ b/kg/queries/infer_subclass_ask.rq
@@ -1,0 +1,2 @@
+PREFIX ex: <http://example.com/reasoner-smoke#>
+ASK { ex:instance1 a ex:Parent . }

--- a/kg/scripts/ci-inference-smoke.ps1
+++ b/kg/scripts/ci-inference-smoke.ps1
@@ -1,0 +1,101 @@
+param(
+    [ValidateSet('rdfs','owlmini')]
+    [string]$Mode = 'rdfs',
+    [string]$AssemblerPath
+)
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$repoRoot = Resolve-Path (Join-Path $PSScriptRoot '..')
+$jena = Join-Path $repoRoot 'tools/jena'
+$fuseki = Join-Path $repoRoot 'tools/fuseki'
+if (-not (Test-Path $jena)) { throw 'Jena not found at tools/jena' }
+if (-not (Test-Path $fuseki)) { throw 'Fuseki not found at tools/fuseki' }
+$batDir = Join-Path $jena 'bat'
+$env:PATH = "$batDir;$env:PATH"
+
+$tdbLoader = Join-Path $batDir 'tdb2_tdbloader.bat'
+if (-not (Test-Path $tdbLoader)) { $tdbLoader = Join-Path $batDir 'tdb2.tdbloader.bat' }
+if (-not (Test-Path $tdbLoader)) { throw 'TDB2 loader script not found' }
+
+$kgDir = Join-Path $repoRoot 'kg'
+$targetDir = Join-Path $kgDir 'target'
+$tdbDir = Join-Path $targetDir 'tdb2'
+if (Test-Path $targetDir) { Remove-Item $targetDir -Recurse -Force }
+New-Item -ItemType Directory -Path $tdbDir | Out-Null
+
+$ttlFiles = Get-ChildItem -Path $kgDir -Filter *.ttl | Where-Object { $_.Name -ne 'shapes.ttl' }
+$fixture = Join-Path $kgDir 'testdata/reasoner_smoke.ttl'
+$allTtls = $ttlFiles.FullName + $fixture
+foreach ($ttl in $allTtls) {
+    & $tdbLoader --loc $tdbDir $ttl
+    if ($LASTEXITCODE -ne 0) { throw "TDB2 load failed for $ttl" }
+}
+
+if ($AssemblerPath) {
+    $assembler = $AssemblerPath
+} else {
+    $assembler = if ($Mode -eq 'rdfs') { Join-Path $kgDir 'assembler/tdb2-inference-rdfs.ttl' } else { Join-Path $kgDir 'assembler/tdb2-inference-owlmini.ttl' }
+}
+$assembler = Resolve-Path $assembler
+
+$reportsDir = Join-Path $kgDir 'reports'
+New-Item -ItemType Directory -Force -Path $reportsDir | Out-Null
+
+$server = Start-Process -FilePath (Join-Path $fuseki 'fuseki-server.bat') -ArgumentList @('--config', $assembler) -PassThru -WindowStyle Hidden
+$ready = $false
+for ($i=0; $i -lt 30; $i++) {
+    try {
+        Invoke-WebRequest -UseBasicParsing http://localhost:3030/\$/ping | Out-Null
+        $ready = $true
+        break
+    } catch {
+        Start-Sleep -Seconds 1
+    }
+}
+if (-not $ready) {
+    if ($server -and -not $server.HasExited) { Stop-Process -Id $server.Id -Force }
+    Write-Error 'Fuseki server failed to start'
+    exit 1
+}
+
+$endpoint = 'http://localhost:3030/ds-inf/sparql'
+$arq = Join-Path $batDir 'arq.bat'
+$queries = @(
+    @{ name = 'subclass'; file = Join-Path $kgDir 'queries/infer_subclass_ask.rq'; details = 'Subclass inference via rdfs:subClassOf'; },
+    @{ name = 'domain-range'; file = Join-Path $kgDir 'queries/infer_domain_range_ask.rq'; details = 'Domain and range infer types'; },
+    @{ name = 'equivalence'; file = Join-Path $kgDir 'queries/infer_equivalence_ask.rq'; details = 'Equivalent classes propagate type'; }
+)
+
+$results = @()
+$fail = $false
+foreach ($q in $queries) {
+    $out = & $arq --query $q.file --service $endpoint --results=JSON 2>$null
+    if ($LASTEXITCODE -ne 0) {
+        $passed = $false
+        $details = 'query failed'
+    } else {
+        $json = $out | ConvertFrom-Json
+        $passed = [bool]$json.boolean
+        $details = $q.details
+    }
+    $results += [pscustomobject]@{ name = $q.name; passed = $passed; details = $details }
+    if (-not $passed) { $fail = $true }
+}
+
+$results | ConvertTo-Json | Set-Content (Join-Path $reportsDir "inference-$Mode.json")
+$results | ForEach-Object { "$($_.name): $($_.passed)" } | Set-Content (Join-Path $reportsDir "inference-$Mode.txt")
+
+$selectQuery = Join-Path $kgDir 'queries/infer_report_select.rq'
+$selectOut = & $arq --query $selectQuery --service $endpoint --results=JSON 2>$null
+$selectPath = Join-Path $reportsDir "inference-$Mode-select.srj"
+$selectOut | Out-File -FilePath $selectPath -Encoding utf8
+
+if ($server -and -not $server.HasExited) { Stop-Process -Id $server.Id -Force }
+
+if ($fail) {
+    Write-Error 'Inference ASK checks failed'
+    exit 1
+}
+Write-Host 'Inference smoke succeeded'
+exit 0

--- a/tests/test_inference_smoke.py
+++ b/tests/test_inference_smoke.py
@@ -1,0 +1,59 @@
+import json
+import pathlib
+import subprocess
+import sys
+import shutil
+
+import pytest
+
+SCRIPT = pathlib.Path('kg/scripts/ci-inference-smoke.ps1')
+JENA_DIR = pathlib.Path('tools') / 'jena'
+FUSEKI_DIR = pathlib.Path('tools') / 'fuseki'
+REPORTS_DIR = pathlib.Path('kg') / 'reports'
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows-only")
+def test_inference_script_exists():
+    assert SCRIPT.exists()
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows-only")
+def test_inference_rdfs_smoke_when_tools_present():
+    if not (JENA_DIR.exists() and FUSEKI_DIR.exists()):
+        pytest.skip("Jena or Fuseki tools missing")
+    if REPORTS_DIR.exists():
+        shutil.rmtree(REPORTS_DIR)
+    result = subprocess.run([
+        "pwsh",
+        str(SCRIPT),
+        "-Mode",
+        "rdfs",
+    ], capture_output=True, text=True)
+    assert result.returncode == 0, result.stdout + result.stderr
+    json_path = REPORTS_DIR / "inference-rdfs.json"
+    select_path = REPORTS_DIR / "inference-rdfs-select.srj"
+    assert json_path.exists()
+    data = json.loads(json_path.read_text())
+    assert all(item["passed"] for item in data)
+    assert select_path.exists()
+    assert select_path.stat().st_size > 0
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows-only")
+def test_inference_owlmini_smoke_when_tools_present():
+    if not (JENA_DIR.exists() and FUSEKI_DIR.exists()):
+        pytest.skip("Jena or Fuseki tools missing")
+    result = subprocess.run([
+        "pwsh",
+        str(SCRIPT),
+        "-Mode",
+        "owlmini",
+    ], capture_output=True, text=True)
+    assert result.returncode == 0, result.stdout + result.stderr
+    json_path = REPORTS_DIR / "inference-owlmini.json"
+    select_path = REPORTS_DIR / "inference-owlmini-select.srj"
+    assert json_path.exists()
+    data = json.loads(json_path.read_text())
+    assert all(item["passed"] for item in data)
+    assert select_path.exists()
+    assert select_path.stat().st_size > 0


### PR DESCRIPTION
## Summary
- Add Fuseki assembler configs for RDFS and OWL Mini inference datasets
- Provide Windows PowerShell script and smoke queries to validate inferred triples over HTTP
- Extend Windows CI with inference smoke job and add Windows-aware pytests

## Testing
- `pytest tests/test_inference_smoke.py -q` *(fails: skipped 3 tests on non-Windows)*


------
https://chatgpt.com/codex/tasks/task_e_68af39526efc8325a019f560da58d1a9