### PR TITLE
B.10 — PROV-O provenance for API-sourced triples + CI lineage checks (Windows)

### DIFF
--- a/.github/workflows/kg-ci.yml
+++ b/.github/workflows/kg-ci.yml
@@ -163,3 +163,66 @@ jobs:
         with:
           name: cassettes
           path: tests/fixtures/cassettes/*.yaml
+
+  provenance-checks:
+    needs: api-contract-tests
+    runs-on: windows-latest
+    env:
+      VCR_RECORD_MODE: none
+      PYTEST_ALLOW_NETWORK: '0'
+    steps:
+      - uses: actions/checkout@v4
+      - name: Guard versions
+        shell: pwsh
+        run: python scripts/check_versions.py
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+      - name: Install Apache Jena and Fuseki
+        shell: pwsh
+        run: |
+          $v = Get-Content tools/versions.json | ConvertFrom-Json
+          $jenaVer = $v.jena
+          $fusekiVer = $v.fuseki
+          New-Item -ItemType Directory -Force -Path tools | Out-Null
+          $jenaArchive = "https://archive.apache.org/dist/jena/binaries/apache-jena-$jenaVer.zip"
+          $jenaMirror = "https://downloads.apache.org/jena/binaries/apache-jena-$jenaVer.zip"
+          try { Invoke-WebRequest -Uri $jenaArchive -OutFile jena.zip -ErrorAction Stop } catch { Invoke-WebRequest -Uri $jenaMirror -OutFile jena.zip }
+          Expand-Archive jena.zip -DestinationPath tools
+          Move-Item tools/apache-jena-$jenaVer tools/jena
+          $fusekiArchive = "https://archive.apache.org/dist/jena/binaries/apache-jena-fuseki-$fusekiVer.zip"
+          $fusekiMirror = "https://downloads.apache.org/jena/binaries/apache-jena-fuseki-$fusekiVer.zip"
+          try { Invoke-WebRequest -Uri $fusekiArchive -OutFile fuseki.zip -ErrorAction Stop } catch { Invoke-WebRequest -Uri $fusekiMirror -OutFile fuseki.zip }
+          Expand-Archive fuseki.zip -DestinationPath tools
+          Move-Item tools/apache-jena-fuseki-$fusekiVer tools/fuseki
+          Test-Path (Join-Path tools/jena 'bat/riot.bat') | Out-Null
+          Test-Path (Join-Path tools/jena 'bat/arq.bat') | Out-Null
+      - name: Export KG with provenance
+        shell: pwsh
+        run: |
+          python - <<'PY'
+from earCrawler.kg.emit_ear import emit_ear
+from earCrawler.kg.triples import emit_tradegov_entities
+from earCrawler.kg.prov import new_prov_graph, write_prov_files
+from pathlib import Path
+g = new_prov_graph()
+fixture = Path('tests/kg/fixtures')
+emit_ear(fixture, Path('kg'), prov_graph=g)
+recs = [{'id':'acme','name':'ACME Corp','country':'US','source_url':'https://trade.gov/api/acme','date':'2024-01-01','sha256':'0'*64}]
+emit_tradegov_entities(recs, Path('kg'), prov_graph=g)
+write_prov_files(g, Path('kg')/'prov')
+with open('kg/ear_triples.ttl','w',encoding='utf-8') as f:
+    f.write(Path('kg/ear.ttl').read_text())
+    f.write(Path('kg/tradegov.ttl').read_text())
+PY
+      - name: Run provenance checks
+        shell: pwsh
+        run: kg/scripts/ci-provenance.ps1
+      - name: Upload provenance reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: provenance-reports
+          path: kg/reports/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
 - VCR recorded fixtures and offline API contract tests.
 - KG enrichment helpers and CLI commands.
 
+## [0.10.0]
+### Added
+- PROV-O provenance for API data with deterministic IRIs.
+- SHACL shapes enforcing minimal provenance.
+- Lineage SPARQL checks wired into Windows CI.
+
 ## [0.8.0]
 ### Added
 - feat(kg): ontology + TTL emitters for EAR/NSF with deterministic output; CLI `kg-emit`

--- a/README.md
+++ b/README.md
@@ -430,3 +430,18 @@ same names override stored secrets. Responses are cached on disk under
 Contract tests ship with [VCR](https://github.com/kevin1024/vcrpy) cassettes so
 CI runs completely offline. To refresh recordings locally set
 `VCR_RECORD_MODE=once` and run the tests; commit the updated files afterwards.
+
+## B.10 Provenance (PROV-O)
+
+API-sourced triples now carry W3C PROV-O lineage. Domain data remains in the
+default graph while provenance quads are written to the named graph
+`urn:graph:prov` under `kg/prov/`. Deterministic IRIs connect
+`prov:Entity` resources to their generating `prov:Activity` and responsible
+`prov:Agent`. Run the lineage checks:
+
+```powershell
+pwsh kg/scripts/ci-provenance.ps1
+```
+
+Reports appear in `kg/reports/` and include counts of missing provenance,
+activity integrity, and a sample SELECT for manual review.

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -162,3 +162,11 @@ pwsh kg/scripts/ci-inference-smoke.ps1 -Mode owlmini
 - Commit updated cassette files after verifying fields.
 - If contract tests drift, compare failing cassettes with live responses and
   adjust normalization logic or update fixtures.
+
+## Provenance checks
+- `kg/scripts/ci-provenance.ps1` validates `kg/prov/prov.ttl`, loads the domain
+  and provenance graphs into TDB2, and executes lineage SPARQL queries.
+- Reports under `kg/reports/lineage-*.{srj,txt}` summarise missing provenance and
+  activity integrity.
+- A non-zero count or `true` ASK result indicates broken lineage links. Re-run
+  emitters with `new_prov_graph()` to regenerate provenance.

--- a/earCrawler/kg/prov.py
+++ b/earCrawler/kg/prov.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+"""Helpers for PROV-O provenance with deterministic IRIs."""
+
+from dataclasses import dataclass
+from datetime import datetime
+from hashlib import sha256
+from typing import Dict, Optional
+
+from rdflib import Graph, Literal, URIRef
+from rdflib.namespace import RDF, FOAF
+
+from .ontology import EAR_NS, DCT, PROV, XSD, graph_with_prefixes, safe_literal
+
+PROV_GRAPH_IRI = URIRef("urn:graph:prov")
+
+
+def _hash(text: str) -> str:
+    return sha256(text.encode("utf-8")).hexdigest()
+
+
+def new_prov_graph() -> Graph:
+    """Return a graph for provenance quads in ``urn:graph:prov``."""
+    g = graph_with_prefixes()
+    g.identifier = PROV_GRAPH_IRI
+    g.bind("foaf", FOAF)
+    return g
+
+
+def mint_agent(domain: str) -> URIRef:
+    norm = domain.replace("http://", "").replace("https://", "").strip("/")
+    norm = norm.replace(".", "_")
+    return EAR_NS[f"agent/{norm}"]
+
+
+def mint_activity(request_url: str, params: Optional[Dict[str, str]] = None) -> URIRef:
+    key = request_url
+    if params:
+        parts = [f"{k}={v}" for k, v in sorted(params.items())]
+        key += "?" + "&".join(parts)
+    digest = _hash(key)[:16]
+    return EAR_NS[f"activity/{digest}"]
+
+
+def mint_request(request_url: str, params: Optional[Dict[str, str]] = None) -> URIRef:
+    key = request_url
+    if params:
+        parts = [f"{k}={v}" for k, v in sorted(params.items())]
+        key += "?" + "&".join(parts)
+    digest = _hash("req:" + key)[:16]
+    return EAR_NS[f"request/{digest}"]
+
+
+def add_provenance(
+    g: Graph,
+    entity_iri: URIRef,
+    *,
+    source_url: str,
+    provider_domain: str,
+    request_url: Optional[str] = None,
+    params: Optional[Dict[str, str]] = None,
+    generated_at: Optional[datetime | str] = None,
+    response_sha256: Optional[str] = None,
+) -> None:
+    """Append provenance quads for ``entity_iri`` to graph ``g``."""
+
+    req_url = request_url or source_url
+    agent = mint_agent(provider_domain)
+    activity = mint_activity(req_url, params)
+    request = mint_request(req_url, params)
+
+    if isinstance(generated_at, str):
+        ts = generated_at
+    else:
+        ts = (generated_at or datetime.utcnow()).isoformat()
+
+    g.add((entity_iri, RDF.type, PROV.Entity))
+    g.add((entity_iri, PROV.wasDerivedFrom, URIRef(source_url)))
+    g.add((entity_iri, PROV.wasGeneratedBy, activity))
+    g.add((entity_iri, PROV.wasAttributedTo, agent))
+    g.add((entity_iri, PROV.generatedAtTime, Literal(ts, datatype=XSD.dateTime)))
+
+    g.add((activity, RDF.type, PROV.Activity))
+    g.add((activity, PROV.used, request))
+    g.add((activity, PROV.wasAssociatedWith, agent))
+    if response_sha256:
+        g.add((activity, EAR_NS.responseHash, safe_literal(response_sha256)))
+
+    g.add((request, RDF.type, PROV.Entity))
+    g.add((request, DCT.source, URIRef(req_url)))
+
+    g.add((agent, RDF.type, PROV.Agent))
+    g.add((agent, FOAF.homepage, URIRef(f"https://{provider_domain}")))
+
+
+def write_prov_files(graph: Graph, out_dir) -> None:
+    """Serialize provenance graph to TTL and N-Quads with sorted statements."""
+    from pathlib import Path
+
+    out_dir = Path(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    ttl_path = out_dir / "prov.ttl"
+    nq_path = out_dir / "prov.nq"
+
+    prefixes = sorted(graph.namespace_manager.namespaces(), key=lambda x: x[0])
+    lines = []
+    nm = graph.namespace_manager
+    for s, p, o in graph:
+        lines.append(f"{s.n3(nm)} {p.n3(nm)} {o.n3(nm)} .")
+    lines.sort()
+    with ttl_path.open("w", encoding="utf-8") as f:
+        for prefix, ns in prefixes:
+            f.write(f"@prefix {prefix}: <{ns}> .\n")
+        f.write("\n")
+        for line in lines:
+            f.write(line + "\n")
+
+    nquads = [q.strip() for q in graph.serialize(format="nquads").splitlines() if q.strip()]
+    nquads.sort()
+    with nq_path.open("w", encoding="utf-8") as f:
+        for line in nquads:
+            f.write(line + "\n")
+
+__all__ = [
+    "new_prov_graph",
+    "add_provenance",
+    "write_prov_files",
+    "mint_agent",
+    "mint_activity",
+    "mint_request",
+    "PROV_GRAPH_IRI",
+]

--- a/kg/queries/lineage_activity_integrity.rq
+++ b/kg/queries/lineage_activity_integrity.rq
@@ -1,0 +1,8 @@
+PREFIX prov: <http://www.w3.org/ns/prov#>
+ASK {
+  ?act a prov:Activity .
+  FILTER(
+    !EXISTS { ?ent prov:wasGeneratedBy ?act } ||
+    !EXISTS { ?act prov:wasAssociatedWith ?agent }
+  )
+}

--- a/kg/queries/lineage_min_required.rq
+++ b/kg/queries/lineage_min_required.rq
@@ -1,0 +1,11 @@
+PREFIX prov: <http://www.w3.org/ns/prov#>
+SELECT (COUNT(*) AS ?cnt)
+WHERE {
+  ?s a prov:Entity .
+  FILTER EXISTS { ?s prov:wasGeneratedBy ?act }
+  FILTER (
+    !EXISTS { ?s prov:wasDerivedFrom ?src } ||
+    !EXISTS { ?s prov:wasAttributedTo ?agent } ||
+    !EXISTS { ?s prov:generatedAtTime ?t }
+  )
+}

--- a/kg/queries/lineage_source_consistency.rq
+++ b/kg/queries/lineage_source_consistency.rq
@@ -1,0 +1,10 @@
+PREFIX prov: <http://www.w3.org/ns/prov#>
+PREFIX dct: <http://purl.org/dc/terms/>
+SELECT ?entity ?activity ?agent ?src
+WHERE {
+  ?entity prov:wasGeneratedBy ?activity ;
+          prov:wasAttributedTo ?agent ;
+          prov:wasDerivedFrom ?src .
+}
+ORDER BY ?entity ?activity ?agent
+LIMIT 10

--- a/kg/scripts/ci-provenance.ps1
+++ b/kg/scripts/ci-provenance.ps1
@@ -1,0 +1,60 @@
+param()
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$repoRoot = Resolve-Path (Join-Path $PSScriptRoot '..')
+$jena = Join-Path $repoRoot 'tools/jena'
+$batDir = Join-Path $jena 'bat'
+$env:PATH = "$batDir;$env:PATH"
+
+$kgDir = Join-Path $repoRoot 'kg'
+$provDir = Join-Path $kgDir 'prov'
+$reportsDir = Join-Path $kgDir 'reports'
+New-Item -ItemType Directory -Force -Path $reportsDir | Out-Null
+
+$provTtl = Join-Path $provDir 'prov.ttl'
+if (-not (Test-Path $provTtl)) { throw 'provenance TTL missing' }
+& (Join-Path $batDir 'riot.bat') --validate $provTtl
+if ($LASTEXITCODE -ne 0) { throw 'RIOT validation failed' }
+
+$tdbDir = Join-Path $kgDir 'target/prov-tdb'
+if (Test-Path $tdbDir) { Remove-Item $tdbDir -Recurse -Force }
+New-Item -ItemType Directory -Force -Path $tdbDir | Out-Null
+$loader = Join-Path $batDir 'tdb2_tdbloader.bat'
+if (-not (Test-Path $loader)) { $loader = Join-Path $batDir 'tdb2.tdbloader.bat' }
+$query = Join-Path $batDir 'tdb2_tdbquery.bat'
+if (-not (Test-Path $query)) { $query = Join-Path $batDir 'tdb2.tdbquery.bat' }
+
+$domainTtl = Join-Path $kgDir 'ear_triples.ttl'
+foreach ($ttl in @($domainTtl, $provTtl)) {
+    & (Join-Path $batDir 'riot.bat') --validate $ttl
+    if ($LASTEXITCODE -ne 0) { throw "RIOT validation failed for $ttl" }
+    & $loader --loc $tdbDir $ttl
+    if ($LASTEXITCODE -ne 0) { throw "TDB2 load failed for $ttl" }
+}
+
+$queries = @(
+    @{ name = 'lineage-min-required'; file = Join-Path $kgDir 'queries/lineage_min_required.rq'; type = 'count'; },
+    @{ name = 'lineage-activity-integrity'; file = Join-Path $kgDir 'queries/lineage_activity_integrity.rq'; type = 'ask'; },
+    @{ name = 'lineage-source-consistency'; file = Join-Path $kgDir 'queries/lineage_source_consistency.rq'; type = 'select'; }
+)
+
+foreach ($q in $queries) {
+    $out = Join-Path $reportsDir ($q.name + '.srj')
+    & $query --loc $tdbDir --results=JSON $q.file | Out-File -FilePath $out -Encoding utf8
+    if ($LASTEXITCODE -ne 0) { throw "Query failed for $($q.name)" }
+    if ($q.type -eq 'count') {
+        $info = Get-Content $out | ConvertFrom-Json
+        $cnt = [int]$info.results.bindings[0].cnt.value
+        Set-Content -Path (Join-Path $reportsDir ($q.name + '.txt')) -Value $cnt
+        if ($cnt -ne 0) { throw 'Provenance minimum check failed' }
+    } elseif ($q.type -eq 'ask') {
+        $info = Get-Content $out | ConvertFrom-Json
+        $bool = [bool]$info.boolean
+        Set-Content -Path (Join-Path $reportsDir ($q.name + '.txt')) -Value $bool
+        if ($bool) { throw 'Activity integrity check failed' }
+    }
+}
+
+Write-Host 'Provenance checks succeeded'
+exit 0

--- a/kg/shapes_prov.ttl
+++ b/kg/shapes_prov.ttl
@@ -1,0 +1,20 @@
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+provsh:ApiDerivedEntityShape a sh:NodeShape ;
+  sh:targetClass prov:Entity ;
+  sh:property [ sh:path prov:wasDerivedFrom ; sh:minCount 1 ; sh:nodeKind sh:IRI ] ;
+  sh:property [ sh:path prov:wasGeneratedBy ; sh:minCount 1 ; sh:class prov:Activity ] ;
+  sh:property [ sh:path prov:wasAttributedTo ; sh:minCount 1 ; sh:class prov:Agent ] ;
+  sh:property [ sh:path prov:generatedAtTime ; sh:minCount 1 ; sh:datatype xsd:dateTime ] .
+
+provsh:ActivityShape a sh:NodeShape ;
+  sh:targetClass prov:Activity ;
+  sh:property [ sh:path prov:used ; sh:minCount 1 ; ] ;
+  sh:property [ sh:path prov:wasAssociatedWith ; sh:minCount 1 ; sh:class prov:Agent ] .
+
+provsh:AgentShape a sh:NodeShape ;
+  sh:targetClass prov:Agent ;
+  sh:property [ sh:path foaf:homepage ; sh:minCount 1 ; sh:nodeKind sh:IRI ] .

--- a/tests/test_provenance_contract.py
+++ b/tests/test_provenance_contract.py
@@ -1,0 +1,58 @@
+import json
+import pathlib
+import subprocess
+import sys
+
+import pytest
+from rdflib import ConjunctiveGraph
+
+from earCrawler.kg.emit_ear import emit_ear
+from earCrawler.kg.triples import emit_tradegov_entities
+from earCrawler.kg.prov import new_prov_graph, write_prov_files
+
+KG_DIR = pathlib.Path('kg')
+SCRIPT_SHACL = KG_DIR / 'scripts' / 'ci-shacl-owl.ps1'
+SCRIPT_PROV = KG_DIR / 'scripts' / 'ci-provenance.ps1'
+
+
+@pytest.mark.skipif(sys.platform != 'win32', reason='Windows-only')
+def test_provenance_contract(tmp_path):
+    prov_g = new_prov_graph()
+    fixture_dir = pathlib.Path('tests/kg/fixtures')
+    emit_ear(fixture_dir, KG_DIR, prov_graph=prov_g)
+    records = [
+        {
+            'id': 'acme',
+            'name': 'ACME Corp',
+            'country': 'US',
+            'source_url': 'https://trade.gov/api/acme',
+            'date': '2024-01-01',
+            'sha256': '0' * 64,
+        }
+    ]
+    emit_tradegov_entities(records, KG_DIR, prov_graph=prov_g)
+    write_prov_files(prov_g, KG_DIR / 'prov')
+    # combine domain TTLs
+    domain = KG_DIR / 'ear_triples.ttl'
+    with domain.open('w', encoding='utf-8') as out:
+        out.write((KG_DIR / 'ear.ttl').read_text())
+        out.write((KG_DIR / 'tradegov.ttl').read_text())
+
+    subprocess.run(['pwsh', str(SCRIPT_SHACL)], check=True)
+    conf = (KG_DIR / 'reports' / 'shacl-conforms.txt').read_text().strip()
+    assert conf == 'true'
+
+    subprocess.run(['pwsh', str(SCRIPT_PROV)], check=True)
+    info = json.loads((KG_DIR / 'reports' / 'lineage-min-required.srj').read_text())
+    assert int(info['results']['bindings'][0]['cnt']['value']) == 0
+    info2 = json.loads((KG_DIR / 'reports' / 'lineage-activity-integrity.srj').read_text())
+    assert info2['boolean'] is False
+    sample = json.loads((KG_DIR / 'reports' / 'lineage-source-consistency.srj').read_text())
+    assert sample['results']['bindings'], 'expect sample rows'
+
+    g = ConjunctiveGraph()
+    g.parse(domain, format='turtle')
+    g.parse(KG_DIR / 'prov' / 'prov.ttl', format='turtle')
+    q = open(KG_DIR / 'queries' / 'lineage_min_required.rq').read()
+    res = list(g.query(q))
+    assert int(res[0][0]) == 0


### PR DESCRIPTION
## Summary
- add provenance helper and deterministic IRIs for API data
- emit PROV quads for Trade.gov and Federal Register outputs
- validate provenance via SHACL and lineage SPARQL checks on Windows CI

## Testing
- `pip install vcrpy`
- `pip install pytest-socket`
- `pytest` *(fails: ModuleNotFoundError: No module named 'tenacity')*
- `PYTHONPATH=. pytest tests/test_provenance_contract.py` *(fails: ModuleNotFoundError: No module named 'tenacity')*


------
https://chatgpt.com/codex/tasks/task_e_68af49eec9248325b292ed21fa3e1bf7