### PR TITLE
Only cache JSON HTTP responses

### DIFF
--- a/earCrawler/utils/http_cache.py
+++ b/earCrawler/utils/http_cache.py
@@ -44,10 +44,16 @@ class HTTPCache:
             resp._content = cached["body"].encode("utf-8")
             resp.status_code = 200
             return resp
-        data = {
-            "etag": resp.headers.get("ETag"),
-            "last_modified": resp.headers.get("Last-Modified"),
-            "body": resp.text,
-        }
-        path.write_text(json.dumps(data, ensure_ascii=False, sort_keys=True), encoding="utf-8")
+
+        content_type = resp.headers.get("Content-Type", "")
+        if content_type.startswith("application/json"):
+            data = {
+                "etag": resp.headers.get("ETag"),
+                "last_modified": resp.headers.get("Last-Modified"),
+                "body": str(resp.text) if resp.text is not None else "",
+            }
+            path.write_text(
+                json.dumps(data, ensure_ascii=False, sort_keys=True),
+                encoding="utf-8",
+            )
         return resp

--- a/tests/unit/test_http_cache.py
+++ b/tests/unit/test_http_cache.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import requests
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+from earCrawler.utils.http_cache import HTTPCache
+
+
+class DummySession:
+    def __init__(self, response: requests.Response):
+        self._response = response
+
+    def get(self, url, params, headers, timeout):  # pragma: no cover - simple pass-through
+        return self._response
+
+
+def make_response(text: str | None, content_type: str) -> requests.Response:
+    resp = requests.Response()
+    resp.status_code = 200
+    resp._content = (text or "").encode("utf-8")
+    resp.headers["Content-Type"] = content_type
+    return resp
+
+
+def test_skip_cache_for_non_json(tmp_path: Path) -> None:
+    cache = HTTPCache(tmp_path)
+    resp = make_response("not json", "text/html")
+    session = DummySession(resp)
+    cache.get(session, "https://example.com", {})
+    assert not list(tmp_path.iterdir())
+
+
+def test_cache_written_for_json(tmp_path: Path) -> None:
+    cache = HTTPCache(tmp_path)
+    resp = make_response("{\"a\":1}", "application/json; charset=utf-8")
+    session = DummySession(resp)
+    cache.get(session, "https://example.com", {})
+    assert any(tmp_path.iterdir())


### PR DESCRIPTION
## Summary
- Only persist HTTP responses if Content-Type is application/json
- Avoid TypeError by coercing resp.text to string before caching
- Add unit tests ensuring non-JSON responses are not cached

## Testing
- `pytest tests/unit/test_http_cache.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68af4ec2f6fc8325ad5269daf2e27e6c