### PR TITLE
Allow socket usage in service tests

### DIFF
--- a/tests/service/test_kg_service.py
+++ b/tests/service/test_kg_service.py
@@ -4,7 +4,17 @@ import importlib
 from typing import Any
 from urllib.error import HTTPError
 
+import pytest
 from fastapi.testclient import TestClient
+from pytest_socket import disable_socket, enable_socket, socket_allow_hosts
+
+
+@pytest.fixture(autouse=True)
+def _allow_socket():
+    socket_allow_hosts(["testserver", "localhost"])
+    enable_socket()
+    yield
+    disable_socket()
 
 
 class _GoodWrapper:

--- a/tests/service/test_sparql_service.py
+++ b/tests/service/test_sparql_service.py
@@ -3,7 +3,18 @@ from __future__ import annotations
 import importlib
 from typing import Any
 from urllib.error import HTTPError
+
+import pytest
 from fastapi.testclient import TestClient
+from pytest_socket import disable_socket, enable_socket, socket_allow_hosts
+
+
+@pytest.fixture(autouse=True)
+def _allow_socket():
+    socket_allow_hosts(["testserver", "localhost"])
+    enable_socket()
+    yield
+    disable_socket()
 
 
 def _load_app(monkeypatch, wrapper_cls):


### PR DESCRIPTION
## Summary
- enable local socket operations in KG service tests
- enable local socket operations in SPARQL service tests

## Testing
- `pytest tests/service/test_kg_service.py -q`
- `pytest tests/service/test_sparql_service.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68af4ec789248325b3a395fb1fbc14cb