### PR TITLE
refactor: rename lookup_entity parameter

### DIFF
--- a/api_clients/tradegov_client.py
+++ b/api_clients/tradegov_client.py
@@ -59,9 +59,9 @@ class TradeGovClient:
             )
         return results
 
-    def lookup_entity(self, name: str) -> Dict[str, str]:
-        """Return the first entity result for ``name`` or an empty dict."""
-        results = self.search(name, limit=1)
+    def lookup_entity(self, query: str) -> Dict[str, str]:
+        """Return the first entity result for ``query`` or an empty dict."""
+        results = self.search(query, limit=1)
         return results[0] if results else {}
 
     # Backwards compatibility aliases


### PR DESCRIPTION
## Summary
- rename lookup_entity's `name` parameter to `query`

## Testing
- `pytest tests/test_api_clients_stubs.py::test_tradegov_client_has_lookup_entity -q`
- `pytest tests/clients/test_tradegov_client.py::test_lookup_entity -q`


------
https://chatgpt.com/codex/tasks/task_e_68af4ec95edc8325b108c6424edaae0c