### PR TITLE
feat: remove Jena archive size check

### DIFF
--- a/earCrawler/utils/jena_tools.py
+++ b/earCrawler/utils/jena_tools.py
@@ -112,9 +112,6 @@ def ensure_jena(download: bool = True, version: str | None = None) -> Path:
             f"Failed to download Jena. Attempts: {details}. Set JENA_VERSION to override."
         )
 
-    if zip_path.stat().st_size < 5 * 1024 * 1024:
-        raise RuntimeError("Downloaded Jena archive is too small")
-
     temp_dir = root / "tools" / "jena-temp"
     if temp_dir.exists():
         shutil.rmtree(temp_dir)


### PR DESCRIPTION
## Summary
- drop Apache Jena download size check
- rely on `_valid_install` after extraction to ensure required Windows scripts

## Testing
- `pytest -q --disable-warnings` *(fails: pytest_socket.SocketBlockedError)*

------
https://chatgpt.com/codex/tasks/task_e_68af4ecb4a3c83258592223d66116952