### PR TITLE
Handle named graph identifiers in provenance helper

### DIFF
--- a/earCrawler/kg/ontology.py
+++ b/earCrawler/kg/ontology.py
@@ -15,10 +15,17 @@ PROV = Namespace("http://www.w3.org/ns/prov#")
 XSD = Namespace("http://www.w3.org/2001/XMLSchema#")
 
 
-def graph_with_prefixes() -> Graph:
-    """Return a graph pre-bound with common prefixes."""
+def graph_with_prefixes(*, identifier: rdflib.term.Identifier | None = None) -> Graph:
+    """Return a graph pre-bound with common prefixes.
 
-    g = Graph()
+    Parameters
+    ----------
+    identifier:
+        Optional identifier for the graph. When provided the returned
+        :class:`~rdflib.Graph` will use this value as its named graph IRI.
+    """
+
+    g = Graph(identifier=identifier)
     g.bind("ear", EAR_NS)
     g.bind("ent", ENT_NS)
     g.bind("dct", DCT)

--- a/earCrawler/kg/prov.py
+++ b/earCrawler/kg/prov.py
@@ -21,8 +21,7 @@ def _hash(text: str) -> str:
 
 def new_prov_graph() -> Graph:
     """Return a graph for provenance quads in ``urn:graph:prov``."""
-    g = graph_with_prefixes()
-    g.identifier = PROV_GRAPH_IRI
+    g = graph_with_prefixes(identifier=PROV_GRAPH_IRI)
     g.bind("foaf", FOAF)
     return g
 


### PR DESCRIPTION
## Summary
- allow `graph_with_prefixes` to accept an optional `identifier` for named graphs
- build provenance graphs with `graph_with_prefixes(identifier=PROV_GRAPH_IRI)` and remove manual identifier assignment

## Testing
- `PYTHONPATH=. PYTEST_ALLOW_NETWORK=1 pytest tests/kg -q`

------
https://chatgpt.com/codex/tasks/task_e_68af4ecdf7d083258baf13cca3521c8c