### PR TITLE
Bootstrap Jena and Fuseki in KG CI scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,9 @@ Outputs `data\\kg\\ear.ttl` and `data\\kg\\nsf.ttl`. Re-running the command with
 - `kg/ear_ontology.ttl`: RDF schema for paragraphs & entities.
 - `python -m earCrawler.cli kg-export`: Export TTL triples.
 - Start Fuseki: `fuseki-server --config config/fuseki-config.ttl`
+- The PowerShell scripts under `kg/scripts` require `pwsh` (PowerShell 7) and
+  will auto-download Apache Jena and Fuseki into `tools/jena` and `tools/fuseki`
+  when missing.
 ### Load triples without installing Jena
 ```
 # Export TTL

--- a/kg/scripts/ci-inference-smoke.ps1
+++ b/kg/scripts/ci-inference-smoke.ps1
@@ -5,8 +5,9 @@ param(
 )
 $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version Latest
-
-$repoRoot = Resolve-Path (Join-Path $PSScriptRoot '..')
+ 
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../..')).Path
+& python -c "import pathlib, importlib.util; repo = pathlib.Path(r'$repoRoot'); spec = importlib.util.spec_from_file_location('jena_tools', repo / 'earCrawler/utils/jena_tools.py'); mod = importlib.util.module_from_spec(spec); spec.loader.exec_module(mod); mod.ensure_jena(); mod.ensure_fuseki()" | Out-Null
 $jena = Join-Path $repoRoot 'tools/jena'
 $fuseki = Join-Path $repoRoot 'tools/fuseki'
 if (-not (Test-Path $jena)) { throw 'Jena not found at tools/jena' }

--- a/kg/scripts/ci-provenance.ps1
+++ b/kg/scripts/ci-provenance.ps1
@@ -1,8 +1,8 @@
 param()
 $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version Latest
-
-$repoRoot = Resolve-Path (Join-Path $PSScriptRoot '..')
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../..')).Path
+& python -c "import pathlib, importlib.util; repo = pathlib.Path(r'$repoRoot'); spec = importlib.util.spec_from_file_location('jena_tools', repo / 'earCrawler/utils/jena_tools.py'); mod = importlib.util.module_from_spec(spec); spec.loader.exec_module(mod); mod.ensure_jena(); mod.ensure_fuseki()" | Out-Null
 $jena = Join-Path $repoRoot 'tools/jena'
 $batDir = Join-Path $jena 'bat'
 $env:PATH = "$batDir;$env:PATH"

--- a/kg/scripts/ci-roundtrip.ps1
+++ b/kg/scripts/ci-roundtrip.ps1
@@ -2,7 +2,8 @@ param()
 $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version Latest
 
-$repoRoot = Resolve-Path (Join-Path $PSScriptRoot '..')
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../..')).Path
+& python -c "import pathlib, importlib.util; repo = pathlib.Path(r'$repoRoot'); spec = importlib.util.spec_from_file_location('jena_tools', repo / 'earCrawler/utils/jena_tools.py'); mod = importlib.util.module_from_spec(spec); spec.loader.exec_module(mod); mod.ensure_jena(); mod.ensure_fuseki()" | Out-Null
 $jena = Join-Path $repoRoot 'tools/jena'
 $fuseki = Join-Path $repoRoot 'tools/fuseki'
 $batDir = Join-Path $jena 'bat'

--- a/kg/scripts/ci-shacl-owl.ps1
+++ b/kg/scripts/ci-shacl-owl.ps1
@@ -1,8 +1,9 @@
 param()
 $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version Latest
-
-$repoRoot = Resolve-Path (Join-Path $PSScriptRoot '..')
+ 
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../..')).Path
+& python -c "import pathlib, importlib.util; repo = pathlib.Path(r'$repoRoot'); spec = importlib.util.spec_from_file_location('jena_tools', repo / 'earCrawler/utils/jena_tools.py'); mod = importlib.util.module_from_spec(spec); spec.loader.exec_module(mod); mod.ensure_jena(); mod.ensure_fuseki()" | Out-Null
 $jena = Join-Path $repoRoot 'tools/jena'
 $fuseki = Join-Path $repoRoot 'tools/fuseki'
 if (-not (Test-Path $jena)) { throw 'Jena not found at tools/jena' }


### PR DESCRIPTION
## Summary
- Automatically install Apache Jena and Fuseki via `ensure_jena` and new `ensure_fuseki`
- Add bootstrap step to KG PowerShell scripts using embedded Python
- Document auto-bootstrap and PowerShell 7 requirement in README

## Testing
- `PYTHONPATH=. pytest tests/kg/test_fuseki.py -vv`
- `pwsh kg/scripts/ci-shacl-owl.ps1` *(fails later; creates tools/jena and tools/fuseki)*

------
https://chatgpt.com/codex/tasks/task_e_68af62958af88325897da10b8e319144