### PR TITLE
Handle Jena tooling dependencies

### DIFF
--- a/kg/scripts/ci-inference-smoke.ps1
+++ b/kg/scripts/ci-inference-smoke.ps1
@@ -12,6 +12,8 @@ $jena = Join-Path $repoRoot 'tools/jena'
 $fuseki = Join-Path $repoRoot 'tools/fuseki'
 if (-not (Test-Path $jena)) { throw 'Jena not found at tools/jena' }
 if (-not (Test-Path $fuseki)) { throw 'Fuseki not found at tools/fuseki' }
+$env:JENA_HOME = $jena
+$env:FUSEKI_HOME = $fuseki
 $batDir = Join-Path $jena 'bat'
 $env:PATH = "$batDir;$env:PATH"
 

--- a/kg/scripts/ci-roundtrip.ps1
+++ b/kg/scripts/ci-roundtrip.ps1
@@ -6,6 +6,8 @@ $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../..')).Path
 & python -c "import pathlib, importlib.util; repo = pathlib.Path(r'$repoRoot'); spec = importlib.util.spec_from_file_location('jena_tools', repo / 'earCrawler/utils/jena_tools.py'); mod = importlib.util.module_from_spec(spec); spec.loader.exec_module(mod); mod.ensure_jena(); mod.ensure_fuseki()" | Out-Null
 $jena = Join-Path $repoRoot 'tools/jena'
 $fuseki = Join-Path $repoRoot 'tools/fuseki'
+$env:JENA_HOME = $jena
+$env:FUSEKI_HOME = $fuseki
 $batDir = Join-Path $jena 'bat'
 $env:PATH = "$batDir;$env:PATH"
 $tdbLoader = Join-Path $batDir 'tdb2_tdbloader.bat'
@@ -53,10 +55,12 @@ if ($diff) {
     $classDir = Join-Path $targetDir 'classes'
     New-Item -ItemType Directory -Path $classDir | Out-Null
     $jenaLib = Join-Path $jena 'lib/*'
-    & javac -cp $jenaLib -d $classDir $javaSrc
+    $javacCmd = (Get-Command javac).Source
+    $javaCmd = Join-Path (Split-Path -Parent $javacCmd) 'java'
+    & $javacCmd -cp $jenaLib -d $classDir $javaSrc
     if ($LASTEXITCODE -ne 0) { throw 'javac failed' }
     $cp = "$classDir;" + $jenaLib
-    & java -cp $cp GraphIsoCheck $origNq $dumpNq
+    & $javaCmd -cp $cp GraphIsoCheck $origNq $dumpNq
     if ($LASTEXITCODE -ne 0) { throw 'Graph isomorphism check failed' }
 }
 

--- a/kg/scripts/ci-shacl-owl.ps1
+++ b/kg/scripts/ci-shacl-owl.ps1
@@ -8,6 +8,8 @@ $jena = Join-Path $repoRoot 'tools/jena'
 $fuseki = Join-Path $repoRoot 'tools/fuseki'
 if (-not (Test-Path $jena)) { throw 'Jena not found at tools/jena' }
 if (-not (Test-Path $fuseki)) { throw 'Fuseki not found at tools/fuseki' }
+$env:JENA_HOME = $jena
+$env:FUSEKI_HOME = $fuseki
 $batDir = Join-Path $jena 'bat'
 $env:PATH = "$batDir;$env:PATH"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ bitsandbytes==0.43.1
 peft==0.11.1
 transformers==4.39.3
 fastapi==0.116.1
+rdflib==6.3.2
 pyshacl==0.25.0
 SPARQLWrapper==2.0.0
 

--- a/tests/test_inference_smoke.py
+++ b/tests/test_inference_smoke.py
@@ -1,3 +1,9 @@
+"""Smoke tests for inference scripts using Apache Jena and Fuseki.
+
+These tests require PowerShell, a Java runtime, and network access to
+download the tools on demand. They are only executed on Windows systems.
+"""
+
 import json
 import pathlib
 import subprocess
@@ -10,6 +16,9 @@ SCRIPT = pathlib.Path('kg/scripts/ci-inference-smoke.ps1')
 JENA_DIR = pathlib.Path('tools') / 'jena'
 FUSEKI_DIR = pathlib.Path('tools') / 'fuseki'
 REPORTS_DIR = pathlib.Path('kg') / 'reports'
+
+if shutil.which("pwsh") is None or shutil.which("java") is None:
+    pytest.skip("PowerShell 7 and Java are required", allow_module_level=True)
 
 
 @pytest.mark.skipif(sys.platform != "win32", reason="Windows-only")

--- a/tests/test_provenance_contract.py
+++ b/tests/test_provenance_contract.py
@@ -1,6 +1,7 @@
 """Integration test for provenance contract.
 
-Requires PowerShell 7 (``pwsh``) to be installed and on the PATH.
+Requires PowerShell 7 (``pwsh``) and a Java runtime to be installed and on
+the PATH. The Apache Jena and Fuseki tools are downloaded on demand.
 """
 
 import json
@@ -10,8 +11,8 @@ import shutil
 
 import pytest
 
-if shutil.which("pwsh") is None:
-    pytest.skip("PowerShell 7 not found", allow_module_level=True)
+if shutil.which("pwsh") is None or shutil.which("java") is None:
+    pytest.skip("PowerShell 7 and Java are required", allow_module_level=True)
 
 from rdflib import ConjunctiveGraph
 

--- a/tests/test_roundtrip_ci.py
+++ b/tests/test_roundtrip_ci.py
@@ -1,12 +1,22 @@
+"""Round-trip tests for KG build pipeline using Apache Jena tools.
+
+These tests execute PowerShell scripts that require the Java Development Kit
+and are only run on Windows platforms.
+"""
+
 import pathlib
 import subprocess
 import sys
+import shutil
 
 import pytest
 
 SCRIPT = pathlib.Path(__file__).resolve().parents[1] / 'kg' / 'scripts' / 'ci-roundtrip.ps1'
 JENA_DIR = pathlib.Path('tools') / 'jena'
 FUSEKI_DIR = pathlib.Path('tools') / 'fuseki'
+
+if shutil.which("pwsh") is None or shutil.which("javac") is None:
+    pytest.skip("PowerShell 7 and a JDK with javac are required", allow_module_level=True)
 
 
 @pytest.mark.skipif(sys.platform != "win32", reason="Windows-only")

--- a/tests/test_shacl_owl_smoke.py
+++ b/tests/test_shacl_owl_smoke.py
@@ -1,3 +1,10 @@
+"""Run SHACL validation and OWL smoke checks via Apache Jena tools.
+
+These tests require PowerShell and a Java runtime. The Apache Jena and
+Fuseki distributions are downloaded on demand. Execution is limited to
+Windows environments.
+"""
+
 import json
 import pathlib
 import subprocess
@@ -10,6 +17,9 @@ SCRIPT = pathlib.Path('kg/scripts/ci-shacl-owl.ps1')
 JENA_DIR = pathlib.Path('tools') / 'jena'
 FUSEKI_DIR = pathlib.Path('tools') / 'fuseki'
 REPORTS_DIR = pathlib.Path('kg') / 'reports'
+
+if shutil.which("pwsh") is None or shutil.which("java") is None:
+    pytest.skip("PowerShell 7 and Java are required", allow_module_level=True)
 
 
 @pytest.mark.skipif(sys.platform != "win32", reason="Windows-only")


### PR DESCRIPTION
## Summary
- set Jena/Fuseki env vars in PowerShell scripts and call Java consistently
- document Java and PowerShell requirements for Windows-only tests
- add rdflib to Python dependencies

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af6c19a3a0832591ff4388ad7241d6