### PR TITLE
Ensure Jena/Fuseki env vars for Windows tests

### DIFF
--- a/tests/test_inference_smoke.py
+++ b/tests/test_inference_smoke.py
@@ -5,6 +5,7 @@ download the tools on demand. They are only executed on Windows systems.
 """
 
 import json
+import os
 import pathlib
 import subprocess
 import sys
@@ -32,12 +33,17 @@ def test_inference_rdfs_smoke_when_tools_present():
         pytest.skip("Jena or Fuseki tools missing")
     if REPORTS_DIR.exists():
         shutil.rmtree(REPORTS_DIR)
+    env = {
+        **os.environ,
+        "JENA_HOME": str(JENA_DIR),
+        "FUSEKI_HOME": str(FUSEKI_DIR),
+    }
     result = subprocess.run([
         "pwsh",
         str(SCRIPT),
         "-Mode",
         "rdfs",
-    ], capture_output=True, text=True)
+    ], capture_output=True, text=True, env=env)
     assert result.returncode == 0, result.stdout + result.stderr
     json_path = REPORTS_DIR / "inference-rdfs.json"
     select_path = REPORTS_DIR / "inference-rdfs-select.srj"
@@ -52,12 +58,17 @@ def test_inference_rdfs_smoke_when_tools_present():
 def test_inference_owlmini_smoke_when_tools_present():
     if not (JENA_DIR.exists() and FUSEKI_DIR.exists()):
         pytest.skip("Jena or Fuseki tools missing")
+    env = {
+        **os.environ,
+        "JENA_HOME": str(JENA_DIR),
+        "FUSEKI_HOME": str(FUSEKI_DIR),
+    }
     result = subprocess.run([
         "pwsh",
         str(SCRIPT),
         "-Mode",
         "owlmini",
-    ], capture_output=True, text=True)
+    ], capture_output=True, text=True, env=env)
     assert result.returncode == 0, result.stdout + result.stderr
     json_path = REPORTS_DIR / "inference-owlmini.json"
     select_path = REPORTS_DIR / "inference-owlmini-select.srj"

--- a/tests/test_roundtrip_ci.py
+++ b/tests/test_roundtrip_ci.py
@@ -4,6 +4,7 @@ These tests execute PowerShell scripts that require the Java Development Kit
 and are only run on Windows platforms.
 """
 
+import os
 import pathlib
 import subprocess
 import sys
@@ -11,12 +12,20 @@ import shutil
 
 import pytest
 
-SCRIPT = pathlib.Path(__file__).resolve().parents[1] / 'kg' / 'scripts' / 'ci-roundtrip.ps1'
+SCRIPT = (
+    pathlib.Path(__file__).resolve().parents[1]
+    / 'kg'
+    / 'scripts'
+    / 'ci-roundtrip.ps1'
+)
 JENA_DIR = pathlib.Path('tools') / 'jena'
 FUSEKI_DIR = pathlib.Path('tools') / 'fuseki'
 
 if shutil.which("pwsh") is None or shutil.which("javac") is None:
-    pytest.skip("PowerShell 7 and a JDK with javac are required", allow_module_level=True)
+    pytest.skip(
+        "PowerShell 7 and a JDK with javac are required",
+        allow_module_level=True,
+    )
 
 
 @pytest.mark.skipif(sys.platform != "win32", reason="Windows-only")
@@ -28,7 +37,14 @@ def test_ci_roundtrip_script_exists():
 def test_ci_roundtrip_runs_if_tools_present():
     if not (JENA_DIR.exists() and FUSEKI_DIR.exists()):
         pytest.skip("Jena or Fuseki tools missing")
-    result = subprocess.run(["pwsh", str(SCRIPT)], capture_output=True, text=True)
+    env = {
+        **os.environ,
+        "JENA_HOME": str(JENA_DIR),
+        "FUSEKI_HOME": str(FUSEKI_DIR),
+    }
+    result = subprocess.run(
+        ["pwsh", str(SCRIPT)], capture_output=True, text=True, env=env
+    )
     assert result.returncode == 0, result.stdout + result.stderr
 
 

--- a/tests/test_shacl_owl_smoke.py
+++ b/tests/test_shacl_owl_smoke.py
@@ -6,6 +6,7 @@ Windows environments.
 """
 
 import json
+import os
 import pathlib
 import subprocess
 import sys
@@ -33,7 +34,14 @@ def test_shacl_report_artifacts_when_tools_present():
         pytest.skip("Jena or Fuseki tools missing")
     if REPORTS_DIR.exists():
         shutil.rmtree(REPORTS_DIR)
-    result = subprocess.run(["pwsh", str(SCRIPT)], capture_output=True, text=True)
+    env = {
+        **os.environ,
+        "JENA_HOME": str(JENA_DIR),
+        "FUSEKI_HOME": str(FUSEKI_DIR),
+    }
+    result = subprocess.run(
+        ["pwsh", str(SCRIPT)], capture_output=True, text=True, env=env
+    )
     assert result.returncode == 0, result.stdout + result.stderr
     conforms_path = REPORTS_DIR / "shacl-conforms.txt"
     assert conforms_path.exists()


### PR DESCRIPTION
## Summary
- set `JENA_HOME` and `FUSEKI_HOME` when invoking PowerShell-based Jena scripts
- skip provenance tests when Jena or Fuseki tooling is absent

## Testing
- `flake8 tests/test_inference_smoke.py tests/test_roundtrip_ci.py tests/test_shacl_owl_smoke.py tests/test_provenance_contract.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af716114c08325828523be3819719c