### PR TITLE
Ensure Java 17+ is required for KG integration tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Outputs `data\\kg\\ear.ttl` and `data\\kg\\nsf.ttl`. Re-running the command with
 - Start Fuseki: `fuseki-server --config config/fuseki-config.ttl`
 
 ### Setup for SHACL/OWL validation
-1. Install Java 11+ and verify the installation:
+1. Install Java 17+ and verify the installation:
    ```powershell
    java -version
    ```

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test suite package."""

--- a/tests/java_utils.py
+++ b/tests/java_utils.py
@@ -1,0 +1,28 @@
+import re
+import subprocess
+from typing import Optional
+
+
+def get_java_major_version() -> Optional[int]:
+    """Return the installed Java major version, or None if unavailable."""
+    try:
+        proc = subprocess.run(
+            ["java", "-version"], capture_output=True, text=True, check=False
+        )
+    except OSError:
+        return None
+    out = proc.stderr or proc.stdout
+    if not out:
+        return None
+    first_line = out.splitlines()[0]
+    match = re.search(r"\"(\d+)(?:\.(\d+))?", first_line)
+    if not match:
+        return None
+    major = int(match.group(1))
+    if major == 1 and match.group(2):
+        major = int(match.group(2))
+    return major
+
+
+JAVA_VERSION = get_java_major_version()
+JAVA_VERSION_OK = JAVA_VERSION is not None and JAVA_VERSION >= 17

--- a/tests/test_inference_smoke.py
+++ b/tests/test_inference_smoke.py
@@ -13,13 +13,17 @@ import shutil
 
 import pytest
 
+from .java_utils import JAVA_VERSION_OK
+
 SCRIPT = pathlib.Path('kg/scripts/ci-inference-smoke.ps1')
 JENA_DIR = pathlib.Path('tools') / 'jena'
 FUSEKI_DIR = pathlib.Path('tools') / 'fuseki'
 REPORTS_DIR = pathlib.Path('kg') / 'reports'
 
-if shutil.which("pwsh") is None or shutil.which("java") is None:
-    pytest.skip("PowerShell 7 and Java are required", allow_module_level=True)
+if shutil.which("pwsh") is None or not JAVA_VERSION_OK:
+    pytest.skip(
+        "PowerShell 7 and Java 17+ are required", allow_module_level=True
+    )
 
 
 @pytest.mark.skipif(sys.platform != "win32", reason="Windows-only")

--- a/tests/test_provenance_contract.py
+++ b/tests/test_provenance_contract.py
@@ -12,8 +12,12 @@ import shutil
 
 import pytest
 
-if shutil.which("pwsh") is None or shutil.which("java") is None:
-    pytest.skip("PowerShell 7 and Java are required", allow_module_level=True)
+from .java_utils import JAVA_VERSION_OK
+
+if shutil.which("pwsh") is None or not JAVA_VERSION_OK:
+    pytest.skip(
+        "PowerShell 7 and Java 17+ are required", allow_module_level=True
+    )
 
 from rdflib import ConjunctiveGraph
 

--- a/tests/test_roundtrip_ci.py
+++ b/tests/test_roundtrip_ci.py
@@ -12,6 +12,8 @@ import shutil
 
 import pytest
 
+from .java_utils import JAVA_VERSION_OK
+
 SCRIPT = (
     pathlib.Path(__file__).resolve().parents[1]
     / 'kg'
@@ -21,9 +23,13 @@ SCRIPT = (
 JENA_DIR = pathlib.Path('tools') / 'jena'
 FUSEKI_DIR = pathlib.Path('tools') / 'fuseki'
 
-if shutil.which("pwsh") is None or shutil.which("javac") is None:
+if (
+    shutil.which("pwsh") is None
+    or shutil.which("javac") is None
+    or not JAVA_VERSION_OK
+):
     pytest.skip(
-        "PowerShell 7 and a JDK with javac are required",
+        "PowerShell 7 and a JDK 17+ with javac are required",
         allow_module_level=True,
     )
 

--- a/tests/test_shacl_owl_smoke.py
+++ b/tests/test_shacl_owl_smoke.py
@@ -14,13 +14,17 @@ import shutil
 
 import pytest
 
+from .java_utils import JAVA_VERSION_OK
+
 SCRIPT = pathlib.Path('kg/scripts/ci-shacl-owl.ps1')
 JENA_DIR = pathlib.Path('tools') / 'jena'
 FUSEKI_DIR = pathlib.Path('tools') / 'fuseki'
 REPORTS_DIR = pathlib.Path('kg') / 'reports'
 
-if shutil.which("pwsh") is None or shutil.which("java") is None:
-    pytest.skip("PowerShell 7 and Java are required", allow_module_level=True)
+if shutil.which("pwsh") is None or not JAVA_VERSION_OK:
+    pytest.skip(
+        "PowerShell 7 and Java 17+ are required", allow_module_level=True
+    )
 
 
 @pytest.mark.skipif(sys.platform != "win32", reason="Windows-only")


### PR DESCRIPTION
## Summary
- add utility to check installed Java version
- skip Windows-only KG integration tests unless Java 17+ is available
- document Java 17+ requirement for SHACL/OWL validation

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b1aff97164832587cab11ad5640969