### PR TITLE
Fix incremental state path handling and add snapshot

### DIFF
--- a/kg/snapshots/smoke.srj
+++ b/kg/snapshots/smoke.srj
@@ -1,0 +1,1 @@
+{"head": {"vars": []}, "results": {"bindings": []}}


### PR DESCRIPTION
## Summary
- ensure kg_state builds manifest with relative file paths for cross-platform compatibility
- add missing smoke snapshot used in incremental CI tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b1b9ea98f883258f51c035ff035e81