### PR TITLE
B.12 — Windows installer + CLI entrypoints + signed artifacts

### DIFF
--- a/.github/workflows/kg-ci.yml
+++ b/.github/workflows/kg-ci.yml
@@ -4,10 +4,16 @@ on:
   push:
     paths:
       - 'kg/**'
+      - 'packaging/**'
+      - 'installer/**'
+      - 'scripts/**'
       - '.github/workflows/kg-ci.yml'
   pull_request:
     paths:
       - 'kg/**'
+      - 'packaging/**'
+      - 'installer/**'
+      - 'scripts/**'
       - '.github/workflows/kg-ci.yml'
 
 jobs:
@@ -254,3 +260,29 @@ PY
         with:
           name: provenance-reports
           path: kg/reports/*
+
+  package-smoke:
+    runs-on: windows-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install PyInstaller
+        run: pip install pyinstaller
+      - name: Build EXE
+        shell: pwsh
+        run: scripts/build-exe.ps1
+      - name: Smoke test
+        shell: pwsh
+        run: |
+          $exe = Get-ChildItem dist -Filter 'earctl-*-win64.exe' | Select-Object -First 1
+          & $exe.FullName --version
+          & $exe.FullName diagnose
+      - name: Upload artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: earctl-exe
+          path: dist/earctl-*-win64.exe

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,52 @@
+name: release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install build deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install build pyinstaller pip-licenses
+      - name: Build wheel
+        shell: pwsh
+        run: scripts/build-wheel.ps1
+      - name: Build exe
+        shell: pwsh
+        run: scripts/build-exe.ps1
+      - name: Make installer
+        shell: pwsh
+        run: scripts/make-installer.ps1
+      - name: Sign artifacts
+        shell: pwsh
+        run: scripts/sign-artifacts.ps1
+      - name: Verify signatures
+        shell: pwsh
+        run: |
+          Get-ChildItem dist -Filter *.exe | ForEach-Object { signtool verify /pa $_.FullName }
+      - name: Checksums
+        shell: pwsh
+        run: scripts/checksums.ps1
+      - name: SBOM
+        shell: pwsh
+        run: scripts/sbom.ps1
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            dist/*.whl
+            dist/earctl-*-win64.exe
+            dist/earcrawler-setup-*.exe
+            dist/checksums.sha256
+            dist/sbom.spdx.json
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.12.0]
+### Added
+- Windows packaging: CLI entrypoint `earctl`, PyInstaller executable, Inno Setup installer, signed artifacts, checksums, SBOM, and release workflow.
+
 ## [0.11.0]
 ### Added
 - Incremental KG builds with content hashing, change detection, and diff snapshots.

--- a/README.md
+++ b/README.md
@@ -16,11 +16,19 @@ a RAG (Retrieval Augmented Generation) approach.
 - **Trade.gov API key**
 - **Docker Desktop**
 
-## Installation
-Install earCrawler version 0.2.0 from PyPI:
+## Installation (Windows)
+Download the signed installer or standalone executable from the releases page, or install the wheel from PyPI:
 
 ```bash
-pip install earCrawler==0.2.0
+pip install earCrawler
+```
+
+## CLI usage
+The CLI is available as `earctl`:
+
+```cmd
+earctl --help
+earctl diagnose
 ```
 
 ## Setup

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1,5 +1,15 @@
 # Runbook
 
+## Release packaging
+1. Bump version in `pyproject.toml` and commit.
+2. Tag `vX.Y.Z` and push.
+3. Ensure signing secrets `SIGNING_CERT_PFX_BASE64` and `SIGNING_CERT_PASSWORD` are available when signing.
+4. Run `pwsh scripts/build-wheel.ps1`, `pwsh scripts/build-exe.ps1`, and `pwsh scripts/make-installer.ps1`.
+5. Run `pwsh scripts/sign-artifacts.ps1` to sign executables and installer.
+6. Verify locally with `signtool verify /pa dist\earctl-*.exe` and `signtool verify /pa dist\earcrawler-setup-*.exe`.
+7. Generate checksums and SBOM with `pwsh scripts/checksums.ps1` and `pwsh scripts/sbom.ps1`.
+8. Create a GitHub release and upload the wheel, EXE, installer, checksum, and SBOM files.
+
 ## Deploying LoRA/QLoRA Models
 1. Tag a release: `git tag vX.Y.Z && git push origin vX.Y.Z`.
 2. GitHub Actions builds and pushes `api`, `rag`, and `agent` images to GHCR.

--- a/earCrawler/__init__.py
+++ b/earCrawler/__init__.py
@@ -7,6 +7,6 @@ from importlib.metadata import PackageNotFoundError, version
 try:
     __version__ = version("earCrawler")
 except PackageNotFoundError:  # pragma: no cover - package not installed
-    __version__ = "0.9.0"
+    __version__ = "0.12.0"
 
 __all__ = ["__version__"]

--- a/earCrawler/cli/__init__.py
+++ b/earCrawler/cli/__init__.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+"""CLI entrypoint exposing ``main`` for console_scripts."""
+
+from .__main__ import cli
+
+
+def main() -> None:  # pragma: no cover - thin wrapper
+    cli()
+
+
+__all__ = ["main", "cli"]

--- a/earCrawler/cli/__main__.py
+++ b/earCrawler/cli/__main__.py
@@ -3,10 +3,13 @@ from __future__ import annotations
 """Top-level CLI exposing NSF parser and reports commands."""
 
 import json
+import platform
+import sys
 from pathlib import Path
 
 import click
 
+from earCrawler import __version__
 from earCrawler.core.nsf_case_parser import NSFCaseParser
 from .ear_fetch import fetch_entities, fetch_ear, warm_cache
 from . import reports_cli
@@ -17,8 +20,20 @@ from earCrawler.kg import emit_ear, emit_nsf
 
 
 @click.group()
+@click.version_option(__version__)
 def cli() -> None:  # pragma: no cover - simple wrapper
     """earCrawler command line."""
+
+
+@cli.command()
+def diagnose() -> None:
+    """Print deterministic diagnostic information."""
+    info = {
+        "python": sys.version.split()[0],
+        "platform": platform.platform(),
+        "earCrawler": __version__,
+    }
+    click.echo(json.dumps(info, sort_keys=True, indent=2))
 
 
 @cli.command(name="nsf-parse")

--- a/installer/earcrawler.iss
+++ b/installer/earcrawler.iss
@@ -1,0 +1,34 @@
+#define MyAppVersion GetEnv("EARCRAWLER_VERSION")
+#ifndef MyAppVersion
+  #error EARCRAWLER_VERSION not defined
+#endif
+
+[Setup]
+AppId={{AF55D4E1-7A0F-4B45-9C36-3890B03A1F47}}
+AppName=EarCrawler
+AppVersion={#MyAppVersion}
+DefaultDirName={pf}\EarCrawler
+DefaultGroupName=EarCrawler
+OutputDir=dist
+OutputBaseFilename=earcrawler-setup-{#MyAppVersion}
+SetupIconFile=packaging\assets\app.ico
+DisableProgramGroupPage=yes
+
+[Languages]
+Name: "english"; MessagesFile: "compiler:Default.isl"
+
+[Tasks]
+Name: "addpath"; Description: "Add EarCrawler to PATH"; GroupDescription: "Additional tasks"; Flags: unchecked
+
+[Files]
+Source: "dist\earctl-{#MyAppVersion}-win64.exe"; DestDir: "{app}"; DestName: "earctl.exe"; Flags: ignoreversion
+Source: "README.md"; DestDir: "{app}"; Flags: ignoreversion
+
+[Icons]
+Name: "{group}\EarCrawler CLI"; Filename: "{app}\earctl.exe"
+
+[Registry]
+Root: HKLM; Subkey: "SYSTEM\CurrentControlSet\Control\Session Manager\Environment"; ValueType: expandsz; ValueName: "Path"; ValueData: "{olddata};{app}"; Tasks: addpath; Flags: preservestringtype
+
+[Run]
+Filename: "{app}\README.md"; Description: "Open README"; Flags: postinstall shellexec skipifsilent nowait

--- a/packaging/assets/app.ico.txt
+++ b/packaging/assets/app.ico.txt
@@ -1,0 +1,1 @@
+placeholder icon

--- a/packaging/earctl.spec
+++ b/packaging/earctl.spec
@@ -1,0 +1,36 @@
+# -*- mode: python ; coding: utf-8 -*-
+
+block_cipher = None
+
+
+a = Analysis(
+    ['earCrawler/cli/__main__.py'],
+    pathex=[],
+    binaries=[],
+    datas=[],
+    hiddenimports=[],
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=['tests'],
+    win_no_prefer_redirects=False,
+    win_private_assemblies=False,
+    cipher=block_cipher,
+    noarchive=False,
+)
+pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+exe = EXE(
+    pyz,
+    a.scripts,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    [],
+    name='earctl',
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    console=True,
+    icon='packaging/assets/app.ico',
+)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "earCrawler"
-version = "0.9.0"
+version = "0.12.0"
 description = "EAR AI ingestion, RAG, and analytics pipeline"
 authors = [{ name = "Your Name", email = "you@example.com" }]
 license = { text = "MIT" }
@@ -16,7 +16,7 @@ dependencies = [
 ]
 
 [project.scripts]
-earCrawler = "earCrawler.cli.__main__:main"
+earctl = "earCrawler.cli:main"
 kg-validate = "cli.kg_validate:main"
 
 [tool.setuptools]

--- a/scripts/build-exe.ps1
+++ b/scripts/build-exe.ps1
@@ -1,0 +1,8 @@
+param()
+Remove-Item -Recurse -Force dist -ErrorAction SilentlyContinue
+$version = python - <<'PY'
+from earCrawler import __version__
+print(__version__)
+PY
+pyinstaller --noconfirm --clean --specpath packaging packaging/earctl.spec
+Rename-Item "dist/earctl.exe" "dist/earctl-$version-win64.exe"

--- a/scripts/build-wheel.ps1
+++ b/scripts/build-wheel.ps1
@@ -1,0 +1,4 @@
+param()
+Remove-Item -Recurse -Force dist -ErrorAction SilentlyContinue
+python -m pip install --upgrade build > $null
+python -m build --wheel

--- a/scripts/checksums.ps1
+++ b/scripts/checksums.ps1
@@ -1,0 +1,5 @@
+param()
+Get-ChildItem dist -File | ForEach-Object {
+  $hash = Get-FileHash $_.FullName -Algorithm SHA256
+  "$($hash.Hash)  $($_.Name)"
+} | Out-File -Encoding utf8 dist/checksums.sha256

--- a/scripts/make-installer.ps1
+++ b/scripts/make-installer.ps1
@@ -1,0 +1,10 @@
+param()
+if (-not (Get-Command iscc.exe -ErrorAction SilentlyContinue)) {
+  choco install innosetup --no-progress -y | Out-Null
+}
+$version = python - <<'PY'
+from earCrawler import __version__
+print(__version__)
+PY
+$env:EARCRAWLER_VERSION = $version
+iscc.exe installer/earcrawler.iss

--- a/scripts/sbom.ps1
+++ b/scripts/sbom.ps1
@@ -1,0 +1,3 @@
+param()
+if (!(Test-Path dist)) { New-Item -ItemType Directory -Path dist | Out-Null }
+pip-licenses --format=json --output-file dist/sbom.spdx.json

--- a/scripts/sign-artifacts.ps1
+++ b/scripts/sign-artifacts.ps1
@@ -1,0 +1,26 @@
+param([string]$Dir = "dist")
+$cert = $Env:SIGNING_CERT_PFX_BASE64
+$pwd = $Env:SIGNING_CERT_PASSWORD
+$subject = $Env:SIGNING_SUBJECT
+$thumb = $Env:SIGNING_THUMBPRINT
+$ts = $Env:TIMESTAMP_URL
+if (-not $ts) { $ts = "http://timestamp.digicert.com" }
+
+if (-not $cert -or -not $pwd -or (-not $subject -and -not $thumb)) {
+  Write-Host "sign-artifacts: signing secrets not provided; skipping"
+  exit 0
+}
+
+$temp = Join-Path $env:TEMP ([System.IO.Path]::GetRandomFileName())
+New-Item -ItemType Directory -Path $temp | Out-Null
+$pfx = Join-Path $temp "cert.pfx"
+[IO.File]::WriteAllBytes($pfx, [Convert]::FromBase64String($cert)) | Out-Null
+certutil -f -p $pwd -importpfx $pfx | Out-Null
+
+if ($thumb) { $certArg = "/sha1 $thumb" } else { $certArg = "/n `"$subject`"" }
+Get-ChildItem $Dir -Filter *.exe | ForEach-Object {
+  & signtool.exe sign /fd sha256 /tr $ts /td sha256 $certArg $_.FullName
+  & signtool.exe verify /pa $_.FullName
+}
+Remove-Item $pfx -Force
+Remove-Item $temp -Force

--- a/tests/test_cli_packaging.py
+++ b/tests/test_cli_packaging.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from earCrawler import __version__
+
+
+def test_python_module_version():
+    out = subprocess.check_output([sys.executable, "-m", "earCrawler.cli", "--version"], text=True)
+    assert __version__ in out.strip()
+
+
+def test_python_module_diagnose():
+    out = subprocess.check_output([sys.executable, "-m", "earCrawler.cli", "diagnose"], text=True)
+    data = json.loads(out)
+    assert data["earCrawler"] == __version__
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="EXE only on Windows")
+def test_exe_smoke():
+    exe = next(Path("dist").glob("earctl-*-win64.exe"), None)
+    if exe is None:
+        pytest.skip("exe not built")
+    out = subprocess.check_output([str(exe), "--version"], text=True)
+    assert __version__ in out.strip()
+    out2 = subprocess.check_output([str(exe), "diagnose"], text=True)
+    data = json.loads(out2)
+    assert data["earCrawler"] == __version__


### PR DESCRIPTION
## Summary
- expose `earctl` CLI with `--version` and `diagnose`
- add Windows packaging scripts, PyInstaller spec, and Inno Setup installer
- publish signed wheel/exe/installer with checksums and SBOM via release workflow

## Testing
- `pytest tests/test_cli_packaging.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b86ef60a5083258a453f7413b54531