### PR TITLE
B.14 — Retention & GC (Windows) + UTC timestamp deprecation fix

### DIFF
--- a/.github/workflows/kg-ci.yml
+++ b/.github/workflows/kg-ci.yml
@@ -308,3 +308,24 @@ PY
         with:
           name: telemetry-spool
           path: '${{ env.APPDATA }}\\EarCrawler\\spool'
+
+  gc-dry-run:
+    needs: [provenance-checks, telemetry-tests]
+    runs-on: windows-latest
+    env:
+      VCR_RECORD_MODE: none
+      PYTEST_ALLOW_NETWORK: '0'
+    steps:
+      - uses: actions/checkout@v4
+      - name: Guard versions
+        shell: pwsh
+        run: python scripts/check_versions.py
+      - name: Run GC dry-run
+        shell: pwsh
+        run: kg/scripts/ci-gc.ps1
+      - name: Upload GC reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: gc-reports
+          path: kg/reports/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [0.14.0]
+### Added
+- Centralised retention GC for telemetry, caches, and KG artifacts.
+- Telemetry timestamps now use timezone-aware UTC with ISO-8601 `Z`.
+- CI job runs GC in dry-run mode and uploads reports.
+
 ## [0.12.0]
 ### Added
 - Windows packaging: CLI entrypoint `earctl`, PyInstaller executable, Inno Setup installer, signed artifacts, checksums, SBOM, and release workflow.

--- a/README.md
+++ b/README.md
@@ -496,3 +496,15 @@ changes. When nothing changed the script writes
 `kg/reports/incremental-noop.txt` and exits quickly. When inputs differ it
 re-runs the round-trip, SHACL/OWL, inference, and provenance steps, then writes
 diffs for canonical N-Quads and SPARQL snapshots to `kg/reports/`.
+
+## B.14 Retention & GC
+
+Centralised retention policies govern telemetry spools, API caches, and KG
+artifacts. Preview actions with:
+
+```powershell
+earctl gc --dry-run --target all
+```
+
+Run with `--apply --yes` to delete and record an audit log under
+`kg/reports/`.

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -196,3 +196,13 @@ emitters with `new_prov_graph()` to regenerate provenance.
 - Review `kg/reports/diff-summary.txt` for a human-friendly list of snapshot
   diffs. Ordering issues typically stem from missing `ORDER BY` clauses in
   queries.
+
+## Retention and GC
+- Preview deletions with `earctl gc --dry-run --target all`.
+- Apply with `earctl gc --apply --target all --yes`; audit logs appear under
+  `kg/reports/`.
+- Schedule automatic weekly GC via `scripts/schedule-gc.ps1`, which registers
+  a Task Scheduler job named `EarCrawler-GC`.
+- Adjust defaults in `earCrawler/telemetry/config.py` or override with CLI
+  flags.
+- Inspect `kg/reports/gc-report.json` to review results.

--- a/docs/ops/retention_policy.md
+++ b/docs/ops/retention_policy.md
@@ -1,0 +1,20 @@
+# Retention policy
+
+EarCrawler retains telemetry spools, HTTP caches, and knowledge-graph artifacts
+under configurable limits. The default policies are:
+
+| Target     | Max age (days) | Max total (MB) | Max file (MB) | Keep last |
+|------------|----------------|----------------|---------------|-----------|
+| telemetry  | 30             | 256            | 8             | 10        |
+| cache      | 30             | 512            | 64            | 10        |
+| kg         | 30             | 1024           | 256           | 10        |
+
+Only paths under the whitelist are ever touched:
+`kg/`, `.cache/api/`, `%APPDATA%\EarCrawler\spool`, and
+`%PROGRAMDATA%\EarCrawler\spool`.
+
+Run `earctl gc --dry-run --target all` to preview deletions. Use
+`earctl gc --apply --target all --yes` to delete and write an audit log to
+`kg/reports/gc-audit-<timestamp>.json`.
+
+Telemetry spools can be cleared manually with `earctl telemetry purge`.

--- a/earCrawler/cli/__main__.py
+++ b/earCrawler/cli/__main__.py
@@ -19,6 +19,7 @@ from earCrawler.kg.sparql import SPARQLClient
 from earCrawler.kg import emit_ear, emit_nsf
 from earCrawler.telemetry.hooks import install as install_telem
 from .telemetry import telemetry, crash_test
+from .gc import gc
 
 install_telem()
 
@@ -80,6 +81,7 @@ cli.add_command(fetch_ear)
 cli.add_command(warm_cache)
 cli.add_command(telemetry)
 cli.add_command(crash_test)
+cli.add_command(gc)
 
 
 @cli.command(name="crawl")

--- a/earCrawler/cli/gc.py
+++ b/earCrawler/cli/gc.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import click
+
+from earCrawler.utils import retention
+
+
+@click.command()
+@click.option("--dry-run", "dry_run", is_flag=True, default=False, help="Preview without deleting.")
+@click.option("--apply", "apply", is_flag=True, default=False, help="Delete files.")
+@click.option("--yes", is_flag=True, help="Confirm deletions without prompt.")
+@click.option(
+    "--target",
+    type=click.Choice(["telemetry", "cache", "kg", "all"]),
+    default="all",
+)
+@click.option("--max-age", type=int, default=None, help="Override max age in days.")
+@click.option("--max-mb", type=int, default=None, help="Override total size limit in MB.")
+@click.option("--keep-last", type=int, default=None, help="Override keep_last_n policy.")
+def gc(
+    dry_run: bool,
+    apply: bool,
+    yes: bool,
+    target: str,
+    max_age: int | None,
+    max_mb: int | None,
+    keep_last: int | None,
+) -> None:
+    """Garbage collect caches, telemetry, or KG artifacts."""
+    if dry_run == apply:
+        raise click.UsageError("Specify exactly one of --dry-run or --apply")
+    if apply and not yes and not click.confirm("Apply GC and delete files?"):
+        click.echo("Aborted")
+        return
+    report = retention.run_gc(
+        target=target,
+        dry_run=dry_run,
+        max_days=max_age,
+        max_total_mb=max_mb,
+        keep_last_n=keep_last,
+    )
+    report_dir = Path("kg/reports")
+    report_dir.mkdir(parents=True, exist_ok=True)
+    report_path = report_dir / "gc-report.json"
+    with report_path.open("w", encoding="utf-8") as fh:
+        json.dump(report, fh, indent=2)
+    count = len(report["deleted"] if apply else report["candidates"])
+    click.echo(f"{count} files {'deleted' if apply else 'would be deleted'}")

--- a/earCrawler/cli/telemetry.py
+++ b/earCrawler/cli/telemetry.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+import shutil
 
 import click
 
@@ -51,6 +52,22 @@ def test() -> None:
     ev = cli_run("telemetry-test", 0, 0)
     path = sink.write(ev)
     click.echo(str(path))
+
+
+@telemetry.command()
+@click.option("--yes", is_flag=True, help="Skip confirmation.")
+def purge(yes: bool) -> None:
+    cfg = tconfig.load_config()
+    path = Path(cfg.spool_dir)
+    if not yes and not click.confirm(f"Delete telemetry spool at {path}?"):
+        click.echo("Aborted")
+        return
+    for p in path.glob("*"):
+        if p.is_file():
+            p.unlink(missing_ok=True)
+        elif p.is_dir():
+            shutil.rmtree(p, ignore_errors=True)
+    click.echo("Telemetry spool cleared")
 
 
 @click.command(name="crash-test")

--- a/earCrawler/core/ear_crawler.py
+++ b/earCrawler/core/ear_crawler.py
@@ -22,7 +22,7 @@ import logging
 import re
 import time
 from dataclasses import dataclass, asdict
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Dict, Iterable, Iterator, List, Optional
 
@@ -155,7 +155,9 @@ class EARCrawler:
                     text=text,
                     sha256=sha,
                     citations=citations,
-                    scraped_at=datetime.utcnow().isoformat(sep="T", timespec="seconds") + "Z",
+                    scraped_at=datetime.now(timezone.utc)
+                    .isoformat(timespec="milliseconds")
+                    .replace("+00:00", "Z"),
                     version=version,
                 )
                 new_records.append(record)

--- a/earCrawler/kg/prov.py
+++ b/earCrawler/kg/prov.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 """Helpers for PROV-O provenance with deterministic IRIs."""
 
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 from hashlib import sha256
 from typing import Dict, Optional
 
@@ -71,7 +71,8 @@ def add_provenance(
     if isinstance(generated_at, str):
         ts = generated_at
     else:
-        ts = (generated_at or datetime.utcnow()).isoformat()
+        gtime = (generated_at or datetime.now(timezone.utc)).astimezone(timezone.utc)
+        ts = gtime.isoformat(timespec="milliseconds").replace("+00:00", "Z")
 
     g.add((entity_iri, RDF.type, PROV.Entity))
     g.add((entity_iri, PROV.wasDerivedFrom, URIRef(source_url)))

--- a/earCrawler/telemetry/config.py
+++ b/earCrawler/telemetry/config.py
@@ -41,8 +41,10 @@ class TelemetryConfig:
     sample_rate: float = 1.0
     endpoint: str | None = None
     spool_dir: str = _default_spool_dir()
-    max_spool_mb: int = 10
-    max_file_mb: int = 1
+    max_spool_mb: int = 256
+    max_file_mb: int = 8
+    max_age_days: int = 30
+    keep_last_n: int = 10
     device_id: str = uuid.uuid4().hex
     auth_secret_name: str | None = None
 

--- a/earCrawler/telemetry/events.py
+++ b/earCrawler/telemetry/events.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import platform
-import time
+from datetime import datetime, timezone
 from typing import Any, Dict
 
 from earCrawler import __version__
@@ -12,7 +12,9 @@ def _base(event: str) -> Dict[str, Any]:
     cfg = load_config()
     return {
         "event": event,
-        "ts": int(time.time()),
+        "ts": datetime.now(timezone.utc)
+        .isoformat(timespec="milliseconds")
+        .replace("+00:00", "Z"),
         "version": __version__,
         "os": platform.platform(),
         "python": platform.python_version(),

--- a/earCrawler/utils/retention.py
+++ b/earCrawler/utils/retention.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+import json
+import os
+import shutil
+from dataclasses import dataclass, asdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable, List, Tuple
+
+MB = 1024 * 1024
+
+
+@dataclass
+class RetentionPolicy:
+    max_days: int | None = None
+    max_total_mb: int | None = None
+    max_file_mb: int | None = None
+    keep_last_n: int = 0
+
+    def override(
+        self,
+        max_days: int | None = None,
+        max_total_mb: int | None = None,
+        max_file_mb: int | None = None,
+        keep_last_n: int | None = None,
+    ) -> "RetentionPolicy":
+        pol = RetentionPolicy(**asdict(self))
+        if max_days is not None:
+            pol.max_days = max_days
+        if max_total_mb is not None:
+            pol.max_total_mb = max_total_mb
+        if max_file_mb is not None:
+            pol.max_file_mb = max_file_mb
+        if keep_last_n is not None:
+            pol.keep_last_n = keep_last_n
+        return pol
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _iso(ts: datetime) -> str:
+    return ts.isoformat(timespec="milliseconds").replace("+00:00", "Z")
+
+
+def _whitelist() -> List[Path]:
+    roots: List[Path] = [
+        Path("kg").resolve(),
+        Path(".cache/api").resolve(),
+    ]
+    app = os.getenv("APPDATA") or str(Path.home())
+    roots.append((Path(app) / "EarCrawler" / "spool").resolve())
+    prog = os.getenv("PROGRAMDATA") or app
+    roots.append((Path(prog) / "EarCrawler" / "spool").resolve())
+    return roots
+
+
+def _is_whitelisted(p: Path) -> bool:
+    rp = p.resolve()
+    for root in _whitelist():
+        try:
+            rp.relative_to(root)
+            return True
+        except ValueError:
+            continue
+    return False
+
+
+def _iter_files(base: Path) -> Iterable[Path]:
+    for p in base.rglob("*"):
+        if p.is_file():
+            yield p
+
+
+def _evaluate(base: Path, policy: RetentionPolicy) -> Tuple[List[dict], int]:
+    files = sorted(_iter_files(base), key=lambda p: p.stat().st_mtime, reverse=True)
+    protected = set(files[: policy.keep_last_n]) if policy.keep_last_n > 0 else set()
+    now = _now().timestamp()
+    candidates: List[dict] = []
+    remaining: List[Path] = []
+    for p in files:
+        if p in protected:
+            remaining.append(p)
+            continue
+        size = p.stat().st_size
+        age_days = (now - p.stat().st_mtime) / 86400
+        reason = None
+        if policy.max_days is not None and age_days > policy.max_days:
+            reason = "age"
+        elif policy.max_file_mb is not None and size > policy.max_file_mb * MB:
+            reason = "size"
+        if reason:
+            candidates.append({"path": str(p), "size": size, "reason": reason})
+        else:
+            remaining.append(p)
+    if policy.max_total_mb is not None:
+        total = sum(p.stat().st_size for p in remaining)
+        limit = policy.max_total_mb * MB
+        if total > limit:
+            for p in sorted(remaining, key=lambda p: p.stat().st_mtime):
+                if total <= limit:
+                    break
+                size = p.stat().st_size
+                candidates.append({"path": str(p), "size": size, "reason": "excess"})
+                total -= size
+    candidates.sort(key=lambda c: c["path"])
+    return candidates, len(files)
+
+
+def _delete(paths: Iterable[dict]) -> List[dict]:
+    deleted: List[dict] = []
+    for info in paths:
+        p = Path(info["path"])
+        if p.exists():
+            try:
+                p.unlink()
+            except PermissionError:
+                shutil.rmtree(p, ignore_errors=True)
+        deleted.append(info)
+    return deleted
+
+
+def gc_paths(
+    paths: Iterable[Path],
+    policy: RetentionPolicy,
+    dry_run: bool = True,
+    audit: bool = True,
+) -> dict:
+    candidates: List[dict] = []
+    errors: List[str] = []
+    for base in paths:
+        if not base.exists():
+            continue
+        if not _is_whitelisted(base):
+            errors.append(f"{base} outside whitelist")
+            continue
+        cands, _ = _evaluate(base, policy)
+        candidates.extend(cands)
+    deleted: List[dict] = []
+    if not dry_run and candidates:
+        deleted = _delete(candidates)
+        if audit and deleted:
+            ts = _iso(_now())
+            report_dir = Path("kg/reports")
+            report_dir.mkdir(parents=True, exist_ok=True)
+            audit_path = report_dir / f"gc-audit-{ts}.json"
+            with audit_path.open("w", encoding="utf-8") as fh:
+                json.dump({"timestamp": ts, "deleted": deleted}, fh, indent=2)
+    return {"candidates": candidates, "errors": errors, "deleted": deleted}
+
+
+DEFAULT_POLICIES = {
+    "telemetry": RetentionPolicy(max_days=30, max_total_mb=256, max_file_mb=8, keep_last_n=10),
+    "cache": RetentionPolicy(max_days=30, max_total_mb=512, max_file_mb=64, keep_last_n=10),
+    "kg": RetentionPolicy(max_days=30, max_total_mb=1024, max_file_mb=256, keep_last_n=10),
+}
+
+
+def run_gc(
+    target: str = "all",
+    dry_run: bool = True,
+    max_days: int | None = None,
+    max_total_mb: int | None = None,
+    max_file_mb: int | None = None,
+    keep_last_n: int | None = None,
+) -> dict:
+    targets = ["telemetry", "cache", "kg"] if target == "all" else [target]
+    all_candidates: List[dict] = []
+    errors: List[str] = []
+    policies: dict[str, dict] = {}
+    deleted: List[dict] = []
+
+    paths_map = {
+        "telemetry": [
+            Path(os.getenv("APPDATA") or str(Path.home())) / "EarCrawler" / "spool",
+            Path(os.getenv("PROGRAMDATA") or (os.getenv("APPDATA") or str(Path.home())))
+            / "EarCrawler"
+            / "spool",
+        ],
+        "cache": [
+            Path(".cache/api/tradegov"),
+            Path(".cache/api/federalregister"),
+        ],
+        "kg": [
+            Path("kg/reports"),
+            Path("kg/snapshots"),
+            Path("kg/.kgstate"),
+            Path("kg/target/tdb2"),
+            Path("kg/prov"),
+        ],
+    }
+
+    for tgt in targets:
+        policy = DEFAULT_POLICIES[tgt].override(max_days, max_total_mb, max_file_mb, keep_last_n)
+        policies[tgt] = asdict(policy)
+        report = gc_paths(paths_map[tgt], policy, dry_run=dry_run, audit=not dry_run)
+        for c in report["candidates"]:
+            c["target"] = tgt
+        all_candidates.extend(report["candidates"])
+        errors.extend(report["errors"])
+        deleted.extend(report["deleted"])
+
+    return {
+        "dry_run": dry_run,
+        "targets": targets,
+        "policies": policies,
+        "candidates": sorted(all_candidates, key=lambda c: c["path"]),
+        "errors": errors,
+        "deleted": deleted,
+    }

--- a/kg/scripts/ci-gc.ps1
+++ b/kg/scripts/ci-gc.ps1
@@ -1,0 +1,31 @@
+$ErrorActionPreference = 'Stop'
+$repoRoot = Resolve-Path "$PSScriptRoot/../.."
+Set-Location $repoRoot
+New-Item -ItemType Directory -Force -Path 'kg/reports' | Out-Null
+python -m earCrawler.cli gc --dry-run --target all | Out-Null
+if (-not (Test-Path 'kg/reports/gc-report.json')) {
+    Write-Error 'gc-report.json missing'
+}
+$report = Get-Content 'kg/reports/gc-report.json' | ConvertFrom-Json
+if ($report.errors.Count -gt 0) {
+    Write-Error "GC errors: $($report.errors -join ', ')"
+}
+$allowed = @(
+    (Resolve-Path 'kg').Path,
+    (Resolve-Path '.cache/api').Path,
+    "$Env:APPDATA\EarCrawler\spool",
+    "$Env:PROGRAMDATA\EarCrawler\spool"
+)
+foreach ($cand in $report.candidates) {
+    $p = [System.IO.Path]::GetFullPath($cand.path)
+    $ok = $false
+    foreach ($root in $allowed) {
+        if ($p.StartsWith($root, [System.StringComparison]::OrdinalIgnoreCase)) {
+            $ok = $true
+            break
+        }
+    }
+    if (-not $ok) {
+        Write-Error "Path outside whitelist: $($cand.path)"
+    }
+}

--- a/scripts/schedule-gc.ps1
+++ b/scripts/schedule-gc.ps1
@@ -1,0 +1,10 @@
+$ErrorActionPreference = 'Stop'
+$taskName = 'EarCrawler-GC'
+$action = New-ScheduledTaskAction -Execute 'earctl' -Argument 'gc --apply --target all --yes'
+$trigger = New-ScheduledTaskTrigger -Weekly -DaysOfWeek Sunday -At 3am
+if (Get-ScheduledTask -TaskName $taskName -ErrorAction SilentlyContinue) {
+    Register-ScheduledTask -TaskName $taskName -Action $action -Trigger $trigger -Force | Out-Null
+} else {
+    Register-ScheduledTask -TaskName $taskName -Action $action -Trigger $trigger -Description 'EarCrawler GC' | Out-Null
+}
+Write-Output "Scheduled $taskName"

--- a/tests/retention/test_gc.py
+++ b/tests/retention/test_gc.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+
+from earCrawler.utils import retention
+
+
+def _touch(path: Path, size: int, age_days: int) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("wb") as fh:
+        fh.write(b"0" * size)
+    ts = time.time() - age_days * 86400
+    os.utime(path, (ts, ts))
+
+
+def test_dry_run_and_whitelist(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("APPDATA", str(tmp_path / "APP"))
+    monkeypatch.setenv("PROGRAMDATA", str(tmp_path / "PROG"))
+    spool = Path(os.getenv("APPDATA")) / "EarCrawler" / "spool"
+    old_file = spool / "old.log.gz"
+    large_file = spool / "large.log.gz"
+    recent_file = spool / "recent.log.gz"
+    _touch(old_file, 100, 40)
+    _touch(large_file, 9 * 1024 * 1024, 1)
+    _touch(recent_file, 100, 1)
+
+    report = retention.run_gc(
+        target="telemetry",
+        dry_run=True,
+        max_days=30,
+        max_total_mb=256,
+        keep_last_n=1,
+    )
+    reasons = {Path(c["path"]).name: c["reason"] for c in report["candidates"]}
+    assert reasons["old.log.gz"] == "age"
+    assert reasons["large.log.gz"] == "size"
+    assert "recent.log.gz" not in reasons
+
+    outside = tmp_path / "other" / "bad.txt"
+    _touch(outside, 10, 40)
+    res = retention.gc_paths([outside], retention.RetentionPolicy(max_days=1), dry_run=True)
+    assert res["errors"]
+
+
+def test_apply_deletes_and_audit(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("APPDATA", str(tmp_path / "APP"))
+    monkeypatch.setenv("PROGRAMDATA", str(tmp_path / "PROG"))
+    spool = Path(os.getenv("APPDATA")) / "EarCrawler" / "spool"
+    victim = spool / "victim.log.gz"
+    _touch(victim, 100, 40)
+
+    report = retention.run_gc(target="telemetry", dry_run=False, keep_last_n=0)
+    assert not victim.exists()
+    assert report["deleted"]
+    audit = list((Path("kg") / "reports").glob("gc-audit-*.json"))
+    assert audit

--- a/tests/telemetry/test_datetime_utc_fix.py
+++ b/tests/telemetry/test_datetime_utc_fix.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import warnings
+from datetime import datetime, timezone
+
+from earCrawler.telemetry.config import TelemetryConfig
+from earCrawler.telemetry.events import cli_run
+from earCrawler.telemetry.sink_file import FileSink
+
+
+def test_timestamp_utc(tmp_path):
+    cfg = TelemetryConfig(enabled=True, spool_dir=str(tmp_path))
+    sink = FileSink(cfg)
+    with warnings.catch_warnings(record=True) as w:
+        sink.write(cli_run("cmd", 0, 0))
+    assert not w
+    ev = sink.tail(1)[0]
+    ts = ev["ts"]
+    assert ts.endswith("Z")
+    dt = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+    assert dt.tzinfo == timezone.utc


### PR DESCRIPTION
## Summary
- add centralized retention engine with per-target policies and `earctl gc` CLI
- enforce UTC ISO-8601 timestamps in telemetry and core modules
- scheduleable GC scripts, CI dry-run job, and documentation

## Testing
- `pytest tests/retention/test_gc.py tests/telemetry/test_datetime_utc_fix.py`
- `python -m earCrawler.cli gc --dry-run --target all`


------
https://chatgpt.com/codex/tasks/task_e_68b879be0f188325a81d957f01aa0610