### PR TITLE
B.16 — Reproducible KG snapshot releases with signing and provenance (Windows)

### DIFF
--- a/.github/workflows/kg-ci.yml
+++ b/.github/workflows/kg-ci.yml
@@ -361,3 +361,39 @@ PY
         with:
           name: gc-reports
           path: kg/reports/*
+
+  repro-smoke:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Canonical freeze
+        shell: pwsh
+        run: kg/scripts/canonical-freeze.ps1
+      - name: Manifest
+        shell: pwsh
+        run: scripts/make-manifest.ps1
+      - name: Validate manifest schema
+        run: |
+          python - <<'PY'
+import json, re
+m=json.load(open('kg/canonical/manifest.json'))
+assert 'files' in m
+for f in m['files']:
+    assert set(f.keys())=={'path','size','sha256'}
+    assert re.fullmatch(r'[0-9a-f]{64}', f['sha256'])
+PY
+      - name: Rebuild and compare
+        shell: pwsh
+        run: |
+          Copy-Item kg/canonical/dataset.nq dataset1.nq
+          $snapHashes = @{}
+          Get-ChildItem kg/canonical/snapshots -Filter *.srj | ForEach-Object { $snapHashes[$_.Name] = (Get-FileHash $_.FullName -Algorithm SHA256).Hash; Copy-Item $_.FullName ("orig-" + $_.Name) }
+          Remove-Item -Recurse -Force kg/canonical
+          kg/scripts/canonical-freeze.ps1
+          $hash1 = (Get-FileHash dataset1.nq -Algorithm SHA256).Hash
+          $hash2 = (Get-FileHash kg/canonical/dataset.nq -Algorithm SHA256).Hash
+          if ($hash1 -ne $hash2) { fc /b dataset1.nq kg/canonical/dataset.nq > dist/determinism-diff.txt; exit 1 }
+          foreach ($k in $snapHashes.Keys) {
+            $newHash = (Get-FileHash (Join-Path kg/canonical/snapshots $k) -Algorithm SHA256).Hash
+            if ($snapHashes[$k] -ne $newHash) { fc /b ("orig-"+$k) (Join-Path kg/canonical/snapshots $k) > dist/determinism-diff.txt; exit 1 }
+          }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,27 @@ jobs:
       - name: SBOM
         shell: pwsh
         run: scripts/sbom.ps1
+      - name: Canonical freeze
+        shell: pwsh
+        run: kg/scripts/canonical-freeze.ps1
+      - name: Canonical ZIP
+        shell: pwsh
+        run: scripts/make-canonical-zip.ps1 -Version ${{ github.ref_name }}
+      - name: Manifest
+        shell: pwsh
+        run: scripts/make-manifest.ps1
+      - name: Sign manifest
+        shell: pwsh
+        run: scripts/sign-manifest.ps1
+      - name: Provenance attestation
+        shell: pwsh
+        run: scripts/provenance-attest.ps1
+      - name: Determinism check
+        shell: pwsh
+        run: scripts/rebuild-compare.ps1 -Version ${{ github.ref_name }}
+      - name: Update changelog
+        shell: pwsh
+        run: scripts/changelog-update.ps1 -NextVersion ${{ github.ref_name }}
       - name: Release
         uses: softprops/action-gh-release@v1
         with:
@@ -48,5 +69,11 @@ jobs:
             dist/earcrawler-setup-*.exe
             dist/checksums.sha256
             dist/sbom.spdx.json
+            kg/canonical/manifest.json
+            kg/canonical/provenance.json
+            kg/canonical/release_notes.md
+            kg/canonical/checksums.sha256
+            dist/*.zip
+            scripts/verify-release.ps1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.16.0]
+### Added
+- Reproducible KG snapshot releases with signed manifest and provenance.
+
 ## [0.15.0]
 ### Added
 - Hermetic toolchain with Jena/Fuseki checksum verification.

--- a/docs/ops/provenance_format.md
+++ b/docs/ops/provenance_format.md
@@ -1,0 +1,13 @@
+# Provenance Format
+
+The `provenance.json` file records build metadata for reproducibility.
+
+Fields:
+- `git_commit`: commit hash used for the build.
+- `manifest_sha256`: SHA256 digest of `manifest.json`.
+- `run_id`: CI workflow run identifier.
+- `runner_os`: operating system of the builder.
+- `tool_versions_sha256`: hash of `tools/versions.json`.
+- `build_timestamp`: UTC time of the build in ISO-8601 `Z` format.
+
+Verify by recomputing file hashes and comparing fields to expected values.

--- a/docs/ops/release_process.md
+++ b/docs/ops/release_process.md
@@ -1,0 +1,15 @@
+# Release Process
+
+This document describes reproducible KG release steps.
+
+1. Run `kg/scripts/canonical-freeze.ps1` to produce canonical files under `kg/canonical/`.
+2. Create deterministic archive with `scripts/make-canonical-zip.ps1`.
+3. Generate `manifest.json` and `checksums.sha256` via `scripts/make-manifest.ps1`.
+4. Optionally sign the manifest using `scripts/sign-manifest.ps1` (requires secrets).
+5. Record provenance with `scripts/provenance-attest.ps1`.
+6. Verify determinism: `scripts/rebuild-compare.ps1`.
+7. Use `scripts/verify-release.ps1` to validate a downloaded release offline.
+
+Environment variables:
+- `SOURCE_DATE_EPOCH` – Unix timestamp used for fixed file times.
+- `SIGNING_CERT_PFX_BASE64` and `SIGNING_CERT_PASSWORD` – optional signing material.

--- a/kg/scripts/canonical-freeze.ps1
+++ b/kg/scripts/canonical-freeze.ps1
@@ -1,0 +1,64 @@
+param(
+    [string]$SnapshotDir = "kg/snapshots",
+    [string]$OutputDir = "kg/canonical"
+)
+
+# Ensure output directory
+New-Item -ItemType Directory -Force -Path $OutputDir | Out-Null
+New-Item -ItemType Directory -Force -Path (Join-Path $OutputDir 'snapshots') | Out-Null
+
+# Convert Unix epoch to DateTime
+if ($env:SOURCE_DATE_EPOCH) {
+    $epoch = [int64]$env:SOURCE_DATE_EPOCH
+    $fixedTime = [DateTimeOffset]::FromUnixTimeSeconds($epoch).UtcDateTime
+} else {
+    $fixedTime = [DateTime]::SpecifyKind([DateTime]::Parse('2000-01-01T00:00:00Z'), 'Utc')
+}
+
+function ConvertTo-CanonicalJson($obj) {
+    if ($obj -is [System.Collections.IDictionary]) {
+        $ordered = [ordered]@{}
+        foreach ($key in ($obj.Keys | Sort-Object)) {
+            $ordered[$key] = ConvertTo-CanonicalJson $obj[$key]
+        }
+        return $ordered
+    } elseif ($obj -is [System.Collections.IEnumerable] -and $obj -isnot [string]) {
+        return @($obj | ForEach-Object { ConvertTo-CanonicalJson $_ })
+    } else {
+        return $obj
+    }
+}
+
+# Sort dataset.nq if present
+$datasetSrc = Join-Path $SnapshotDir 'dataset.nq'
+if (Test-Path $datasetSrc) {
+    $lines = Get-Content $datasetSrc | Sort-Object
+    $datasetDest = Join-Path $OutputDir 'dataset.nq'
+    $lines | Set-Content -Path $datasetDest -Encoding utf8
+}
+
+# Normalize JSON snapshots
+Get-ChildItem -Path $SnapshotDir -Filter *.srj -Recurse | ForEach-Object {
+    $rel = [IO.Path]::GetRelativePath($SnapshotDir, $_.FullName)
+    $dest = Join-Path $OutputDir 'snapshots'
+    $dest = Join-Path $dest $rel
+    $destDir = Split-Path $dest -Parent
+    New-Item -ItemType Directory -Force -Path $destDir | Out-Null
+    $json = Get-Content $_.FullName -Raw | ConvertFrom-Json -AsHashtable
+    $canon = ConvertTo-CanonicalJson $json
+    $canon | ConvertTo-Json -Depth 100 | Set-Content -Path $dest -Encoding utf8
+}
+
+# versions.json with tool hash
+$toolsPath = 'tools/versions.json'
+if (Test-Path $toolsPath) {
+    $hash = (Get-FileHash $toolsPath -Algorithm SHA256).Hash.ToLower()
+    $tools = Get-Content $toolsPath -Raw | ConvertFrom-Json
+    $versions = [ordered]@{ tools = $tools; tools_sha256 = $hash }
+    $versions | ConvertTo-Json -Depth 10 | Set-Content -Path (Join-Path $OutputDir 'versions.json') -Encoding utf8
+}
+
+# Set fixed timestamps
+Get-ChildItem -Path $OutputDir -Recurse | Where-Object { -not $_.PSIsContainer } | ForEach-Object {
+    $_.LastWriteTimeUtc = $fixedTime
+}

--- a/scripts/changelog-update.ps1
+++ b/scripts/changelog-update.ps1
@@ -1,0 +1,29 @@
+param(
+    [string]$NextVersion
+)
+
+$lastTag = (git describe --tags --abbrev=0)
+$commits = git log "$lastTag..HEAD" --format="%s"
+$added = @()
+$fixed = @()
+foreach ($c in $commits) {
+    if ($c -like 'feat*') { $added += ($c -replace 'feat[^:]*:','').Trim() }
+    elseif ($c -like 'fix*') { $fixed += ($c -replace 'fix[^:]*:','').Trim() }
+}
+
+$section = "## [$NextVersion]`n"
+if ($added.Count -gt 0) {
+    $section += "### Added`n"
+    foreach ($a in $added) { $section += "- $a`n" }
+}
+if ($fixed.Count -gt 0) {
+    $section += "### Fixed`n"
+    foreach ($f in $fixed) { $section += "- $f`n" }
+}
+$section += "`n"
+
+$changelog = Get-Content CHANGELOG.md -Raw
+Set-Content CHANGELOG.md ($section + $changelog) -Encoding utf8
+Set-Content release_notes.md $section -Encoding utf8
+New-Item -ItemType Directory -Force -Path 'kg/canonical' | Out-Null
+Set-Content 'kg/canonical/release_notes.md' $section -Encoding utf8

--- a/scripts/make-canonical-zip.ps1
+++ b/scripts/make-canonical-zip.ps1
@@ -1,0 +1,29 @@
+param(
+    [string]$SourceDir = "kg/canonical",
+    [string]$OutputDir = "dist",
+    [string]$Version = "dev",
+    [string]$Date = (Get-Date -Format 'yyyyMMdd')
+)
+
+Add-Type -AssemblyName System.IO.Compression.FileSystem
+
+New-Item -ItemType Directory -Force -Path $OutputDir | Out-Null
+$zipName = "earcrawler-kg-$Version-$Date-snapshot.zip"
+$zipPath = Join-Path $OutputDir $zipName
+if (Test-Path $zipPath) { Remove-Item $zipPath }
+
+if ($env:SOURCE_DATE_EPOCH) {
+    $epoch = [int64]$env:SOURCE_DATE_EPOCH
+    $fixedTime = [DateTimeOffset]::FromUnixTimeSeconds($epoch)
+} else {
+    $fixedTime = [DateTimeOffset]::new(2000,1,1,0,0,0,[TimeSpan]::Zero)
+}
+
+$files = Get-ChildItem -Path $SourceDir -Recurse | Where-Object { -not $_.PSIsContainer } | Sort-Object FullName
+$zip = [System.IO.Compression.ZipFile]::Open($zipPath, [System.IO.Compression.ZipArchiveMode]::Create)
+foreach ($f in $files) {
+    $relative = [IO.Path]::GetRelativePath($SourceDir, $f.FullName).Replace('\','/')
+    $entry = $zip.CreateEntryFromFile($f.FullName, $relative)
+    $entry.LastWriteTime = $fixedTime
+}
+$zip.Dispose()

--- a/scripts/make-manifest.ps1
+++ b/scripts/make-manifest.ps1
@@ -1,0 +1,30 @@
+param(
+    [string]$CanonicalDir = "kg/canonical",
+    [string]$DistDir = "dist"
+)
+
+New-Item -ItemType Directory -Force -Path $CanonicalDir | Out-Null
+$manifestPath = Join-Path $CanonicalDir 'manifest.json'
+$checksumsPath = Join-Path $CanonicalDir 'checksums.sha256'
+if (Test-Path $manifestPath) { Remove-Item $manifestPath }
+if (Test-Path $checksumsPath) { Remove-Item $checksumsPath }
+$files = @()
+
+Get-ChildItem -Path $CanonicalDir -Recurse | Where-Object { -not $_.PSIsContainer } | Sort-Object FullName | ForEach-Object {
+    $rel = [IO.Path]::GetRelativePath((Get-Item '.').FullName, $_.FullName).Replace('\\','/')
+    $hash = (Get-FileHash $_.FullName -Algorithm SHA256).Hash.ToLower()
+    $files += [ordered]@{ path = $rel; size = $_.Length; sha256 = $hash }
+}
+
+if (Test-Path $DistDir) {
+    Get-ChildItem -Path $DistDir -Filter *.zip | Sort-Object FullName | ForEach-Object {
+        $rel = [IO.Path]::GetRelativePath((Get-Item '.').FullName, $_.FullName).Replace('\\','/')
+        $hash = (Get-FileHash $_.FullName -Algorithm SHA256).Hash.ToLower()
+        $files += [ordered]@{ path = $rel; size = $_.Length; sha256 = $hash }
+    }
+}
+
+$manifest = [ordered]@{ files = $files }
+$manifest | ConvertTo-Json -Depth 5 | Set-Content -Path $manifestPath -Encoding utf8
+$checksums = $files | ForEach-Object { "$($_.sha256) *$($_.path)" }
+$checksums | Set-Content -Path $checksumsPath -Encoding utf8

--- a/scripts/provenance-attest.ps1
+++ b/scripts/provenance-attest.ps1
@@ -1,0 +1,21 @@
+param(
+    [string]$ManifestPath = "kg/canonical/manifest.json",
+    [string]$OutPath = "kg/canonical/provenance.json"
+)
+
+$manifestHash = (Get-FileHash $ManifestPath -Algorithm SHA256).Hash.ToLower()
+$commit = (git rev-parse HEAD).Trim()
+$runId = $env:GITHUB_RUN_ID
+$runner = $env:RUNNER_OS
+$timestamp = (Get-Date -Format 'yyyy-MM-ddTHH:mm:ssZ')
+$toolsHash = (Get-FileHash 'tools/versions.json' -Algorithm SHA256).Hash.ToLower()
+
+$prov = [ordered]@{
+    git_commit = $commit
+    manifest_sha256 = $manifestHash
+    run_id = $runId
+    runner_os = $runner
+    tool_versions_sha256 = $toolsHash
+    build_timestamp = $timestamp
+}
+$prov | ConvertTo-Json -Depth 5 | Set-Content -Path $OutPath -Encoding utf8

--- a/scripts/rebuild-compare.ps1
+++ b/scripts/rebuild-compare.ps1
@@ -1,0 +1,30 @@
+param(
+    [string]$Version = "dev"
+)
+
+$env:SOURCE_DATE_EPOCH = $env:SOURCE_DATE_EPOCH ?? '946684800'
+
+# First build
+if (Test-Path 'kg/canonical') { Remove-Item -Recurse -Force 'kg/canonical' }
+if (Test-Path 'dist') { Remove-Item -Recurse -Force 'dist' }
+kg/scripts/canonical-freeze.ps1
+scripts/make-canonical-zip.ps1 -Version $Version
+$zip1 = Get-ChildItem dist -Filter '*.zip' | Select-Object -First 1
+Copy-Item $zip1.FullName 'dist/first.zip'
+
+# Second build
+if (Test-Path 'kg/canonical') { Remove-Item -Recurse -Force 'kg/canonical' }
+if (Test-Path 'dist') { Remove-Item -Recurse -Force 'dist' }
+kg/scripts/canonical-freeze.ps1
+scripts/make-canonical-zip.ps1 -Version $Version
+$zip2 = Get-ChildItem dist -Filter '*.zip' | Select-Object -First 1
+
+$hash1 = (Get-FileHash 'dist/first.zip' -Algorithm SHA256).Hash
+$hash2 = (Get-FileHash $zip2.FullName -Algorithm SHA256).Hash
+if ($hash1 -ne $hash2) {
+    fc /b 'dist/first.zip' $zip2.FullName > 'dist/determinism-diff.txt'
+    Write-Error 'Determinism check failed.'
+    exit 1
+} else {
+    Write-Host 'Deterministic build confirmed.'
+}

--- a/scripts/sign-manifest.ps1
+++ b/scripts/sign-manifest.ps1
@@ -1,0 +1,37 @@
+param(
+    [string]$ManifestPath = "kg/canonical/manifest.json"
+)
+
+$certB64 = $env:SIGNING_CERT_PFX_BASE64
+if (-not $certB64) {
+    Write-Host 'No signing certificate provided; skipping.'
+    return
+}
+if (-not $env:SIGNING_CERT_PASSWORD) {
+    Write-Host 'SIGNING_CERT_PASSWORD not set; skipping.'
+    return
+}
+
+$bytes = [Convert]::FromBase64String($certB64)
+$pfx = New-TemporaryFile
+[IO.File]::WriteAllBytes($pfx, $bytes)
+$pwd = ConvertTo-SecureString $env:SIGNING_CERT_PASSWORD -AsPlainText -Force
+$cert = Get-PfxCertificate -FilePath $pfx -Password $pwd
+
+$content = Get-Content -Path $ManifestPath -Encoding Byte -Raw
+$cms = New-Object System.Security.Cryptography.Pkcs.ContentInfo,($content)
+$signed = New-Object System.Security.Cryptography.Pkcs.SignedCms($cms,$false)
+$signer = New-Object System.Security.Cryptography.Pkcs.CmsSigner($cert)
+$signed.ComputeSignature($signer)
+[IO.File]::WriteAllBytes("$ManifestPath.sig", $signed.Encode())
+
+# verify
+$verify = New-Object System.Security.Cryptography.Pkcs.SignedCms
+$verify.Decode([IO.File]::ReadAllBytes("$ManifestPath.sig"))
+try {
+    $verify.CheckSignature($true)
+    Write-Host 'Signature verified.'
+} catch {
+    Write-Error 'Signature verification failed.'
+    exit 1
+}

--- a/scripts/verify-release.ps1
+++ b/scripts/verify-release.ps1
@@ -1,0 +1,31 @@
+param(
+    [string]$ManifestPath = "kg/canonical/manifest.json",
+    [string]$BaseDir = "."
+)
+
+$manifest = Get-Content $ManifestPath -Raw | ConvertFrom-Json
+foreach ($f in $manifest.files) {
+    $path = Join-Path $BaseDir $f.path
+    if (-not (Test-Path $path)) {
+        Write-Error "Missing file $($f.path)"
+        exit 1
+    }
+    $hash = (Get-FileHash $path -Algorithm SHA256).Hash.ToLower()
+    if ($hash -ne $f.sha256.ToLower()) {
+        Write-Error "Hash mismatch for $($f.path)"
+        exit 1
+    }
+}
+if (Test-Path "$ManifestPath.sig") {
+    $content = Get-Content -Path $ManifestPath -Encoding Byte -Raw
+    $sig = [IO.File]::ReadAllBytes("$ManifestPath.sig")
+    $cms = New-Object System.Security.Cryptography.Pkcs.SignedCms
+    $cms.Decode($sig)
+    try {
+        $cms.CheckSignature($true)
+    } catch {
+        Write-Error 'Signature verification failed.'
+        exit 1
+    }
+}
+Write-Host 'All files verified.'

--- a/tests/release/test_canonical_sorting.py
+++ b/tests/release/test_canonical_sorting.py
@@ -1,0 +1,36 @@
+import json
+import os
+import subprocess
+import zipfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def run_ps(script, *args, env=None):
+    cmd = ["pwsh", "-File", str(ROOT / script)] + list(args)
+    env_vars = dict(os.environ)
+    if env:
+        env_vars.update(env)
+    subprocess.run(cmd, check=True, cwd=ROOT, env=env_vars)
+
+
+def test_canonical_sorting(tmp_path):
+    snap_dir = ROOT / "kg" / "snapshots"
+    snap_dir.mkdir(parents=True, exist_ok=True)
+    (snap_dir / "dataset.nq").write_text("b .\na .\n", encoding="utf-8")
+    (snap_dir / "sample.srj").write_text('{"b":1,"a":2}', encoding="utf-8")
+    env = dict(SOURCE_DATE_EPOCH="946684800")
+    run_ps("kg/scripts/canonical-freeze.ps1", env=env)
+    # dataset.nq sorted
+    lines = (ROOT / "kg" / "canonical" / "dataset.nq").read_text().splitlines()
+    assert lines == sorted(lines)
+    # JSON keys sorted
+    srj_text = (ROOT / "kg" / "canonical" / "snapshots" / "sample.srj").read_text()
+    assert srj_text.index("\"a\"") < srj_text.index("\"b\"")
+    # ZIP timestamps
+    run_ps("scripts/make-canonical-zip.ps1", "-Version", "test", env=env)
+    zip_path = next((ROOT / "dist").glob("*.zip"))
+    with zipfile.ZipFile(zip_path, "r") as zf:
+        for info in zf.infolist():
+            assert info.date_time == (2000, 1, 1, 0, 0, 0)

--- a/tests/release/test_manifest_schema.py
+++ b/tests/release/test_manifest_schema.py
@@ -1,0 +1,32 @@
+import json
+import os
+import re
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+def run_ps(script, *args, env=None):
+    cmd = ["pwsh", "-File", str(ROOT / script)] + list(args)
+    env_vars = dict(os.environ)
+    if env:
+        env_vars.update(env)
+    subprocess.run(cmd, check=True, cwd=ROOT, env=env_vars)
+
+def test_manifest_schema(tmp_path):
+    env = dict(SOURCE_DATE_EPOCH="946684800")
+    snap_dir = ROOT / "kg" / "snapshots"
+    snap_dir.mkdir(parents=True, exist_ok=True)
+    (snap_dir / "dataset.nq").write_text("b .\na .\n", encoding="utf-8")
+    (snap_dir / "sample.srj").write_text('{"b":1,"a":2}', encoding="utf-8")
+    run_ps("kg/scripts/canonical-freeze.ps1", env=env)
+    run_ps("scripts/make-canonical-zip.ps1", env=env)
+    run_ps("scripts/make-manifest.ps1", env=env)
+    manifest_path = ROOT / "kg" / "canonical" / "manifest.json"
+    data = json.loads(manifest_path.read_text())
+    assert isinstance(data.get("files"), list)
+    for f in data["files"]:
+        assert set(f.keys()) == {"path", "size", "sha256"}
+        assert re.fullmatch(r"[0-9a-f]{64}", f["sha256"])
+        assert not str(f["path"]).startswith("\\")
+        assert f["size"] > 0

--- a/tests/release/test_verify_script.py
+++ b/tests/release/test_verify_script.py
@@ -1,0 +1,28 @@
+import os
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def run_ps(script, *args, env=None, check=True):
+    cmd = ["pwsh", "-File", str(ROOT / script)] + list(args)
+    env_vars = dict(os.environ)
+    if env:
+        env_vars.update(env)
+    return subprocess.run(cmd, cwd=ROOT, env=env_vars, check=check)
+
+
+def test_verify_detects_tamper(tmp_path):
+    env = dict(SOURCE_DATE_EPOCH="946684800")
+    run_ps("kg/scripts/canonical-freeze.ps1", env=env)
+    # add simple file
+    target = ROOT / "kg" / "canonical" / "foo.txt"
+    target.write_text("hello", encoding="utf-8")
+    run_ps("scripts/make-manifest.ps1", env=env)
+    # verification passes
+    run_ps("scripts/verify-release.ps1", env=env)
+    # tamper
+    target.write_text("evil", encoding="utf-8")
+    res = run_ps("scripts/verify-release.ps1", env=env, check=False)
+    assert res.returncode != 0


### PR DESCRIPTION
## Summary
- add canonical-freeze PowerShell build for deterministic KG snapshots
- generate reproducible zip, manifest, checksums, signing, provenance and changelog automation
- document release process and provenance format with verification tests

## Testing
- `pytest tests/release -q`
- `pytest -q` *(fails: Downloaded Jena archive missing expected folder)*

------
https://chatgpt.com/codex/tasks/task_e_68b89ed144a0832586c4b393a47913eb