### PR TITLE
feat: add RBAC and audit ledger

### DIFF
--- a/.github/workflows/kg-ci.yml
+++ b/.github/workflows/kg-ci.yml
@@ -455,3 +455,21 @@ PY
             kg/reports/reconcile-summary.json
             kg/reports/reconcile-conflicts.json
             kg/reports/reconcile-ci.txt
+
+  access-audit:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Access audit
+        shell: pwsh
+        env:
+          EARCTL_TELEMETRY_DISABLE: '1'
+        run: kg/scripts/ci-access-audit.ps1
+      - name: Upload access artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: access-audit
+          path: |
+            kg/reports/access-audit.txt
+            ${{ env.PROGRAMDATA }}\EarCrawler\audit\*.jsonl

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.19.0]
+### Added
+- RBAC and tamper-evident audit ledger with Windows Credential Manager enforcement.
+
 ## [0.18.0]
 ### Added
 - Deterministic reconciliation with thresholds, conflict reports and CI gates.

--- a/README.md
+++ b/README.md
@@ -75,6 +75,18 @@ earctl crash-test  # writes a crash report to the spool
 
 See `docs/privacy/telemetry_policy.md` for details and how to purge data.
 
+## Access & Audit
+
+RBAC and audit logging protect sensitive operations. Check your roles and verify
+ledger integrity:
+
+```cmd
+earctl policy whoami
+earctl audit verify
+```
+
+See `docs/ops/access_control.md` and `docs/ops/audit_ledger.md` for details.
+
 ## Testing
 Run the CPU test suite:
 

--- a/docs/ops/access_control.md
+++ b/docs/ops/access_control.md
@@ -1,0 +1,28 @@
+# Access Control
+
+`earctl` enforces role based access control (RBAC) using `security/policy.yml`.
+Roles:
+
+- `admin` – full access.
+- `maintainer` – build, release, reconcile and monitoring commands.
+- `operator` – CI, inference and garbage collection.
+- `reader` – read only diagnostics and query commands.
+
+The policy file maps commands to minimal roles. Users can be granted roles via
+`overrides` in the policy file or through bearer tokens stored in the Windows
+Credential Manager.
+
+Check your identity:
+
+```bash
+$ earctl policy whoami
+```
+
+Dry‑run a command against policy:
+
+```bash
+$ earctl policy test --command "gc --dry-run"
+```
+
+For non‑interactive use a token may be stored under the secret name
+`EARCTL_AUTH_TOKEN`.

--- a/docs/ops/audit_ledger.md
+++ b/docs/ops/audit_ledger.md
@@ -1,0 +1,27 @@
+# Audit Ledger
+
+Commands executed via `earctl` are recorded in a tamper‑evident JSONL ledger.
+Each entry contains a rolling SHA256 hash linking it to the previous event and
+optionally an HMAC if the secret `EARCTL_AUDIT_HMAC_KEY` is present in the
+Windows Credential Manager.
+
+Logs rotate daily and are stored under:
+
+```
+%PROGRAMDATA%\EarCrawler\audit
+```
+
+Verify integrity:
+
+```bash
+$ earctl audit verify
+```
+
+Force rotation:
+
+```bash
+$ earctl audit rotate
+```
+
+Old logs participate in garbage collection via `earctl gc --target audit` and
+are kept for 30 days by default.

--- a/earCrawler/audit/__init__.py
+++ b/earCrawler/audit/__init__.py
@@ -1,0 +1,1 @@
+"""Audit ledger utilities."""

--- a/earCrawler/audit/ledger.py
+++ b/earCrawler/audit/ledger.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import json
+import os
+import platform
+from datetime import datetime, timezone
+from pathlib import Path
+import hashlib
+import hmac as hmaclib
+import subprocess
+import sys
+from typing import Any, Dict, Iterable
+
+from earCrawler.telemetry import redaction
+from earCrawler.security import cred_store
+
+__all__ = ["append_event", "verify_chain", "rotate", "tail", "current_log_path"]
+
+
+def _base_dir() -> Path:
+    override = os.getenv("EARCTL_AUDIT_DIR")
+    if override:
+        return Path(override)
+    prog = os.getenv("PROGRAMDATA") or os.getenv("APPDATA") or str(Path.home())
+    return Path(prog) / "EarCrawler" / "audit"
+
+
+def current_log_path() -> Path:
+    day = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    return _base_dir() / f"{day}.jsonl"
+
+
+def _prev_hash(path: Path) -> str:
+    if not path.exists():
+        return "0" * 64
+    try:
+        with path.open("rb") as fh:
+            fh.seek(0, os.SEEK_END)
+            size = fh.tell()
+            if size == 0:
+                return "0" * 64
+            off = min(1024, size)
+            fh.seek(-off, os.SEEK_END)
+            lines = fh.readlines()[-1:]
+            if not lines:
+                return "0" * 64
+            last = json.loads(lines[0])
+            return last.get("chain_hash", "0" * 64)
+    except Exception:
+        return "0" * 64
+
+
+def _commit_hash() -> str:
+    try:
+        out = subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
+        return out
+    except Exception:
+        return "unknown"
+
+
+def append_event(event: str, user: str, roles: Iterable[str], command: str, args_sanitized: str,
+                 exit_code: int, duration_ms: int) -> None:
+    path = current_log_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    entry: Dict[str, Any] = {
+        "ts": datetime.now(timezone.utc).isoformat(),
+        "event": event,
+        "user": user,
+        "roles": list(roles),
+        "command": command,
+        "args_sanitized": args_sanitized,
+        "exit_code": exit_code,
+        "duration_ms": duration_ms,
+        "host": platform.node(),
+        "commit": _commit_hash(),
+    }
+    prev = _prev_hash(path)
+    entry["chain_prev"] = prev
+    sanitized = dict(entry)
+    sanitized["args_sanitized"] = redaction.redact(entry.get("args_sanitized", ""))
+    base = {k: sanitized[k] for k in sanitized if k not in {"chain_prev", "chain_hash", "hmac"}}
+    canonical = json.dumps(base, sort_keys=True, separators=(",", ":"))
+    sanitized["chain_hash"] = hashlib.sha256((prev + canonical).encode("utf-8")).hexdigest()
+    hmac_key = cred_store.get_secret("EARCTL_AUDIT_HMAC_KEY")
+    if hmac_key:
+        sanitized["hmac"] = hmaclib.new(hmac_key.encode("utf-8"), canonical.encode("utf-8"), hashlib.sha256).hexdigest()
+    try:
+        with path.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(sanitized, ensure_ascii=False) + "\n")
+    except Exception:
+        print("audit log write failed", file=sys.stderr)
+
+
+def rotate() -> Path:
+    path = current_log_path()
+    if path.exists():
+        ts = datetime.now(timezone.utc).strftime("%H%M%S")
+        new_path = path.with_name(f"{path.stem}-{ts}{path.suffix}")
+        path.rename(new_path)
+        return new_path
+    return path
+
+
+def tail(n: int = 50) -> Iterable[dict]:
+    path = current_log_path()
+    if not path.exists():
+        return []
+    with path.open("r", encoding="utf-8") as fh:
+        lines = fh.readlines()[-n:]
+    return [json.loads(line) for line in lines]
+
+
+def verify_chain(path: Path) -> bool:
+    prev = "0" * 64
+    with path.open("r", encoding="utf-8") as fh:
+        for line in fh:
+            entry = json.loads(line)
+            canonical = json.dumps({k: entry[k] for k in entry if k not in {"chain_prev", "chain_hash", "hmac"}},
+                                   sort_keys=True, separators=(",", ":"))
+            expected = hashlib.sha256((prev + canonical).encode("utf-8")).hexdigest()
+            if entry.get("chain_prev") != prev or entry.get("chain_hash") != expected:
+                return False
+            hmac_key = cred_store.get_secret("EARCTL_AUDIT_HMAC_KEY")
+            if hmac_key and entry.get("hmac") != hmaclib.new(hmac_key.encode("utf-8"), canonical.encode("utf-8"), hashlib.sha256).hexdigest():
+                return False
+            prev = entry["chain_hash"]
+    return True

--- a/earCrawler/audit/verify.py
+++ b/earCrawler/audit/verify.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Iterable
+
+from .ledger import verify_chain
+
+
+def verify(path: Path) -> bool:
+    return verify_chain(path)
+
+
+def verify_cli(path: Path) -> int:
+    ok = verify(path)
+    report = {"path": str(path), "ok": ok}
+    print(json.dumps(report))
+    return 0 if ok else 1

--- a/earCrawler/cli/audit.py
+++ b/earCrawler/cli/audit.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import click
+
+from earCrawler.audit import ledger, verify
+from earCrawler.security import policy
+
+
+@click.group()
+@policy.require_role("operator", "admin")
+def audit() -> None:
+    """Audit ledger utilities."""
+
+
+@audit.command(name="verify")
+@click.option("--path", type=click.Path(path_type=Path), default=None)
+@policy.enforce
+def verify_cmd(path: Path | None) -> None:
+    path = path or ledger.current_log_path()
+    ok = verify.verify(path)
+    click.echo(json.dumps({"path": str(path), "ok": ok}))
+    if not ok:
+        raise click.ClickException("audit verification failed")
+
+
+@audit.command(name="rotate")
+@policy.enforce
+def rotate_cmd() -> None:
+    p = ledger.rotate()
+    click.echo(str(p))
+
+
+@audit.command(name="tail")
+@click.option("--n", type=int, default=50)
+@policy.enforce
+def tail_cmd(n: int) -> None:
+    entries = list(ledger.tail(n))
+    for e in entries:
+        click.echo(json.dumps(e))

--- a/earCrawler/cli/auth.py
+++ b/earCrawler/cli/auth.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import sys
+import click
+
+from earCrawler.security import cred_store, policy
+
+
+@click.group()
+@policy.require_role("admin")
+def auth() -> None:
+    """Manage secrets in Windows Credential Manager."""
+
+
+@auth.command(name="set-secret")
+@click.option("--name", required=True)
+@click.option("--from-stdin", is_flag=True, required=True)
+@policy.enforce
+def set_secret(name: str, from_stdin: bool) -> None:
+    """Store a secret read from stdin."""
+    value = sys.stdin.read().strip()
+    cred_store.set_secret(name, value)
+    click.echo("secret stored")
+
+
+@auth.command(name="delete-secret")
+@click.option("--name", required=True)
+@policy.enforce
+def delete_secret(name: str) -> None:
+    cred_store.delete_secret(name)
+    click.echo("secret deleted")
+
+
+@auth.command(name="list")
+@policy.enforce
+def list_secrets() -> None:
+    names = cred_store.list_secrets()
+    for n in names:
+        click.echo(n)

--- a/earCrawler/cli/gc.py
+++ b/earCrawler/cli/gc.py
@@ -6,15 +6,18 @@ from pathlib import Path
 import click
 
 from earCrawler.utils import retention
+from earCrawler.security import policy
 
 
 @click.command()
+@policy.require_role("operator")
+@policy.enforce
 @click.option("--dry-run", "dry_run", is_flag=True, default=False, help="Preview without deleting.")
 @click.option("--apply", "apply", is_flag=True, default=False, help="Delete files.")
 @click.option("--yes", is_flag=True, help="Confirm deletions without prompt.")
 @click.option(
     "--target",
-    type=click.Choice(["telemetry", "cache", "kg", "all"]),
+    type=click.Choice(["telemetry", "cache", "kg", "audit", "all"]),
     default="all",
 )
 @click.option("--max-age", type=int, default=None, help="Override max age in days.")

--- a/earCrawler/cli/policy_cmd.py
+++ b/earCrawler/cli/policy_cmd.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import json
+import shlex
+import click
+
+from earCrawler.security import identity, policy
+
+
+@click.group()
+@policy.require_role("reader")
+def policy_cmd() -> None:
+    """Inspect policy and identity."""
+
+
+@policy_cmd.command(name="whoami")
+@policy.enforce
+def whoami_cmd() -> None:
+    info = identity.whoami()
+    click.echo(json.dumps(info))
+
+
+@policy_cmd.command(name="test")
+@click.option("--command", required=True)
+@policy.enforce
+def test_cmd(command: str) -> None:
+    tokens = shlex.split(command)
+    if not tokens:
+        raise click.UsageError("empty command")
+    pol = policy.load_policy()
+    ident = identity.whoami()
+    cmd = tokens[0]
+    allowed, msg = pol.check_access(ident["user"], cmd, None)
+    click.echo(json.dumps({"allowed": allowed, "message": msg}))

--- a/earCrawler/security/__init__.py
+++ b/earCrawler/security/__init__.py
@@ -1,0 +1,1 @@
+"""Security helpers for earCrawler."""

--- a/earCrawler/security/cred_store.py
+++ b/earCrawler/security/cred_store.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import keyring
+from typing import List
+
+SERVICE = "EarCrawler"
+
+
+def set_secret(name: str, value: str) -> None:
+    keyring.set_password(SERVICE, name, value)
+
+
+def get_secret(name: str) -> str | None:
+    try:
+        return keyring.get_password(SERVICE, name)
+    except Exception:
+        return None
+
+
+def delete_secret(name: str) -> None:
+    try:
+        keyring.delete_password(SERVICE, name)
+    except Exception:
+        pass
+
+
+def list_secrets() -> List[str]:
+    try:
+        kr = keyring.get_keyring()
+        if hasattr(kr, "_storage"):
+            return list(getattr(kr, "_storage").get(SERVICE, {}).keys())
+    except Exception:
+        return []
+    return []

--- a/earCrawler/security/identity.py
+++ b/earCrawler/security/identity.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+import getpass
+import os
+from typing import Dict
+
+from . import cred_store
+from .policy import load_policy
+
+
+def whoami() -> Dict[str, object]:
+    """Resolve current identity with roles."""
+    user = os.getenv("EARCTL_USER") or getpass.getuser()
+    token = os.environ.get("EARCTL_AUTH_TOKEN") or cred_store.get_secret("EARCTL_AUTH_TOKEN")
+    pol = load_policy()
+    roles = sorted(pol.roles_for_user(user))
+    return {"user": user, "roles": roles, "via_token": bool(token)}

--- a/earCrawler/security/policy.py
+++ b/earCrawler/security/policy.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import os
+import yaml
+from dataclasses import dataclass, field
+from functools import wraps
+from typing import Callable, Iterable, List, Dict, Set, Tuple
+
+import click
+import sys
+import time
+
+from earCrawler.audit import ledger
+from earCrawler.telemetry import redaction
+
+POLICY_PATH = os.path.join("security", "policy.yml")
+
+
+class PolicyError(Exception):
+    """Raised when policy denies access or is misconfigured."""
+
+
+@dataclass
+class Policy:
+    roles: Dict[str, List[str]]
+    commands: Dict[str, List[str]]
+    overrides: Dict[str, Dict[str, List[str] | List[str]]] = field(default_factory=dict)
+
+    def roles_for_user(self, user: str) -> Set[str]:
+        base: Set[str] = set()
+        if user in self.overrides and self.overrides[user].get("roles"):
+            base.update(self.overrides[user]["roles"])
+        return base
+
+    def required_roles_for(self, command: str) -> List[str]:
+        return self.commands.get(command, [])
+
+    def check_access(self, user: str, command: str, required: Iterable[str] | None = None) -> Tuple[bool, str]:
+        roles = self.roles_for_user(user)
+        needed = list(required) if required else self.required_roles_for(command)
+        if not needed:
+            return False, f"command '{command}' is not permitted"
+        # explicit deny
+        deny = set(self.overrides.get(user, {}).get("deny", []))
+        if command in deny:
+            return False, f"{user} is explicitly denied '{command}'"
+        if any(r == "admin" for r in roles):
+            return True, ""
+        if roles.intersection(needed):
+            return True, ""
+        return False, f"command '{command}' requires role(s): {', '.join(needed)}"
+
+
+def load_policy(path: str | None = None) -> Policy:
+    pol_path = path or os.environ.get("EARCTL_POLICY_PATH") or POLICY_PATH
+    with open(pol_path, "r", encoding="utf-8") as fh:
+        data = yaml.safe_load(fh) or {}
+    return Policy(
+        roles=data.get("roles", {}),
+        commands=data.get("commands", {}),
+        overrides=data.get("overrides", {}),
+    )
+
+
+def require_role(*roles: str) -> Callable:
+    """Decorator to declare required roles for a CLI command."""
+
+    def decorator(fn: Callable) -> Callable:
+        @wraps(fn)
+        def wrapped(*args, **kwargs):
+            return fn(*args, **kwargs)
+
+        setattr(wrapped, "required_roles", list(roles))
+        return wrapped
+
+    return decorator
+
+
+def enforce(fn: Callable) -> Callable:
+    """Decorator enforcing policy and emitting audit events."""
+
+    @wraps(fn)
+    def wrapper(*args, **kwargs):
+        ctx = click.get_current_context()
+        parts = ctx.command_path.split()
+        cmd = parts[1] if len(parts) > 1 else parts[0]
+        from . import identity
+        ident = identity.whoami()
+        pol = load_policy()
+        required = getattr(fn, "required_roles", None)
+        allowed, msg = pol.check_access(ident["user"], cmd, required)
+        args_sanitized = str(redaction.redact(" ".join(sys.argv[1:])))
+        if not allowed:
+            ledger.append_event("denied", ident["user"], ident["roles"], cmd, args_sanitized, 1, 0)
+            raise click.ClickException(msg)
+        start = time.time()
+        try:
+            rv = fn(*args, **kwargs)
+            ledger.append_event("command", ident["user"], ident["roles"], cmd, args_sanitized, 0, int((time.time()-start)*1000))
+            return rv
+        except Exception:
+            ledger.append_event("command", ident["user"], ident["roles"], cmd, args_sanitized, 1, int((time.time()-start)*1000))
+            raise
+
+    return wrapper

--- a/earCrawler/utils/retention.py
+++ b/earCrawler/utils/retention.py
@@ -161,6 +161,7 @@ DEFAULT_POLICIES = {
     "telemetry": RetentionPolicy(max_days=30, max_total_mb=256, max_file_mb=8, keep_last_n=10),
     "cache": RetentionPolicy(max_days=30, max_total_mb=512, max_file_mb=64, keep_last_n=10),
     "kg": RetentionPolicy(max_days=30, max_total_mb=1024, max_file_mb=256, keep_last_n=10),
+    "audit": RetentionPolicy(max_days=30, max_total_mb=256, max_file_mb=8, keep_last_n=10),
 }
 
 
@@ -172,7 +173,7 @@ def run_gc(
     max_file_mb: int | None = None,
     keep_last_n: int | None = None,
 ) -> dict:
-    targets = ["telemetry", "cache", "kg"] if target == "all" else [target]
+    targets = ["telemetry", "cache", "kg", "audit"] if target == "all" else [target]
     all_candidates: List[dict] = []
     errors: List[str] = []
     policies: dict[str, dict] = {}
@@ -195,6 +196,10 @@ def run_gc(
             Path("kg/.kgstate"),
             Path("kg/target/tdb2"),
             Path("kg/prov"),
+        ],
+        "audit": [
+            Path(os.getenv("APPDATA") or str(Path.home())) / "EarCrawler" / "audit",
+            Path(os.getenv("PROGRAMDATA") or (os.getenv("APPDATA") or str(Path.home()))) / "EarCrawler" / "audit",
         ],
     }
 

--- a/kg/scripts/ci-access-audit.ps1
+++ b/kg/scripts/ci-access-audit.ps1
@@ -1,0 +1,15 @@
+$ErrorActionPreference = 'Stop'
+$env:EARCTL_USER = 'ci_user'
+
+$report = New-Object System.Collections.ArrayList
+$report.Add((earctl policy whoami)) | Out-Null
+$report.Add((earctl diagnose)) | Out-Null
+try {
+    earctl gc --dry-run | Out-String | Out-Null
+} catch {
+    $report.Add('gc denied') | Out-Null
+}
+$verify = earctl audit verify
+$report.Add($verify) | Out-Null
+New-Item -ItemType Directory -Force -Path kg/reports | Out-Null
+$report | Out-File -FilePath kg/reports/access-audit.txt -Encoding utf8

--- a/security/PLACEHOLDER_AUDIT_SIGNING_CERT.txt
+++ b/security/PLACEHOLDER_AUDIT_SIGNING_CERT.txt
@@ -1,0 +1,2 @@
+This is a placeholder for the audit signing certificate.
+Replace with an actual certificate file during deployment.

--- a/security/policy.yml
+++ b/security/policy.yml
@@ -1,0 +1,29 @@
+roles:
+  admin: ["*"]
+  maintainer: ["build", "reconcile", "release", "provenance", "monitor"]
+  operator: ["run-ci", "snapshots", "inference", "gc"]
+  reader: ["status", "diagnose", "query", "export"]
+commands:
+  diagnose: ["reader"]
+  gc: ["operator"]
+  reconcile: ["maintainer"]
+  policy: ["reader"]
+  auth: ["admin"]
+  audit: ["operator", "admin"]
+  crawl: ["operator"]
+  report: ["reader"]
+  telemetry: ["operator"]
+  fetch-entities: ["operator"]
+  fetch-ear: ["operator"]
+  warm-cache: ["operator"]
+overrides:
+  test_admin:
+    roles: ["admin"]
+  test_reader:
+    roles: ["reader"]
+  test_operator:
+    roles: ["operator"]
+  test_maintainer:
+    roles: ["maintainer"]
+  ci_user:
+    roles: ["reader"]

--- a/tests/audit/test_ledger_chain.py
+++ b/tests/audit/test_ledger_chain.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from earCrawler.audit import ledger, verify
+
+
+def test_chain_and_rotation(tmp_path, monkeypatch):
+    monkeypatch.setenv("EARCTL_AUDIT_DIR", str(tmp_path))
+    ledger.append_event("cmd", "alice", ["reader"], "diagnose", "", 0, 1)
+    ledger.append_event("cmd", "alice", ["reader"], "diagnose", "", 0, 1)
+    path = ledger.current_log_path()
+    assert verify.verify(path)
+    rotated = ledger.rotate()
+    assert rotated.exists()
+    ledger.append_event("cmd", "alice", ["reader"], "diagnose", "", 0, 1)
+    new_path = ledger.current_log_path()
+    assert new_path != rotated
+    assert verify.verify(new_path)

--- a/tests/audit/test_redaction_in_audit.py
+++ b/tests/audit/test_redaction_in_audit.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+import json
+
+from earCrawler.audit import ledger
+
+
+def test_redaction(tmp_path, monkeypatch):
+    monkeypatch.setenv("EARCTL_AUDIT_DIR", str(tmp_path))
+    arg = "mytoken1234567890abcdefg alice@example.com https://x.test?q=secret"
+    ledger.append_event("cmd", "bob", ["reader"], "diagnose", arg, 0, 1)
+    last = list(ledger.tail(1))[0]
+    text = json.dumps(last)
+    assert "alice@example.com" not in text
+    assert "mytoken" not in text
+    assert "secret" not in text
+    assert "[redacted]" in text

--- a/tests/cli/test_policy_whoami.py
+++ b/tests/cli/test_policy_whoami.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+import json
+from click.testing import CliRunner
+
+from earCrawler.cli import cli
+
+
+def test_policy_whoami():
+    runner = CliRunner()
+    res = runner.invoke(cli, ["policy", "whoami"], env={"EARCTL_USER": "test_reader"})
+    assert res.exit_code == 0
+    data = json.loads(res.output)
+    assert set(data.keys()) == {"user", "roles", "via_token"}
+    assert "EARCTL_AUTH_TOKEN" not in res.output

--- a/tests/security/test_cred_store.py
+++ b/tests/security/test_cred_store.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import keyring
+from keyring.backend import KeyringBackend
+
+from earCrawler.security import cred_store
+
+
+class DummyKeyring(KeyringBackend):
+    priority = 1
+
+    def __init__(self):
+        self._storage = {cred_store.SERVICE: {}}
+
+    def get_password(self, service, name):  # pragma: no cover - simple
+        return self._storage.get(service, {}).get(name)
+
+    def set_password(self, service, name, value):  # pragma: no cover - simple
+        self._storage.setdefault(service, {})[name] = value
+
+    def delete_password(self, service, name):  # pragma: no cover - simple
+        self._storage.get(service, {}).pop(name, None)
+
+
+def test_roundtrip(monkeypatch):
+    keyring.set_keyring(DummyKeyring())
+    cred_store.set_secret("FOO", "bar")
+    assert cred_store.get_secret("FOO") == "bar"
+    assert "FOO" in cred_store.list_secrets()
+    cred_store.delete_secret("FOO")
+    assert cred_store.get_secret("FOO") is None

--- a/tests/security/test_policy_enforcement.py
+++ b/tests/security/test_policy_enforcement.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from click.testing import CliRunner
+
+from earCrawler.cli import cli
+
+
+def _invoke(cmd: str, user: str):
+    runner = CliRunner()
+    return runner.invoke(cli, cmd.split(), env={"EARCTL_USER": user})
+
+
+def test_policy_matrix():
+    matrix = [
+        ("diagnose", "test_reader", 0),
+        ("gc --dry-run", "test_reader", 1),
+        ("gc --dry-run", "test_operator", 0),
+        ("policy whoami", "test_reader", 0),
+        ("policy whoami", "test_operator", 1),
+    ]
+    for cmd, user, code in matrix:
+        res = _invoke(cmd, user)
+        assert res.exit_code == code


### PR DESCRIPTION
## Summary
- enforce role-based access for `earctl` commands using `security/policy.yml`
- log tamper-evident audit events with optional HMAC and rotation
- integrate Windows Credential Manager helpers and GC for audit logs

## Testing
- `pytest tests/security tests/audit tests/cli/test_policy_whoami.py -vv`

------
https://chatgpt.com/codex/tasks/task_e_68c08f5862e08325a89f21a4038b5139