### PR TITLE
B.21 — Offline bundle mode with integrity checks and first-run bootstrap (Windows)

### DIFF
--- a/.github/workflows/kg-ci.yml
+++ b/.github/workflows/kg-ci.yml
@@ -200,6 +200,129 @@ jobs:
         with:
           name: inference-reports
           path: kg/reports/*
+
+  offline-bundle-smoke:
+    needs: incremental-scan
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Guard versions
+        shell: pwsh
+        run: python scripts/check_versions.py
+      - name: Build offline bundle
+        shell: pwsh
+        run: scripts/build-offline-bundle.ps1
+      - name: Stage mock tools for smoke test
+        shell: pwsh
+        run: |
+          $bundle = Join-Path $PWD 'dist/offline_bundle'
+          New-Item -ItemType Directory -Force -Path (Join-Path $bundle 'tools/jena/bat') | Out-Null
+          New-Item -ItemType Directory -Force -Path (Join-Path $bundle 'tools/fuseki') | Out-Null
+          @'
+@echo off
+setlocal EnableDelayedExpansion
+set LOC=
+:loop
+if "%1"=="" goto done
+if /I "%1"=="--loc" (
+  set LOC=%2
+  shift
+  shift
+  goto loop
+)
+shift
+goto loop
+:done
+if "%LOC%"=="" set LOC=%cd%
+if not exist "%LOC%" mkdir "%LOC%"
+echo mock-load>"%LOC%\loader.ok"
+exit /b 0
+'@ | Set-Content -Path (Join-Path $bundle 'tools/jena/bat/tdb2_tdbloader.bat') -Encoding ascii
+          Copy-Item -Path (Join-Path $bundle 'tools/jena/bat/tdb2_tdbloader.bat') -Destination (Join-Path $bundle 'tools/jena/bat/tdb2.tdbloader.bat') -Force
+          @'
+@echo off
+setlocal EnableDelayedExpansion
+set PORT=3030
+:loop
+if "%1"=="" goto run
+if /I "%1"=="--port" (
+  set PORT=%2
+  shift
+  shift
+  goto loop
+)
+shift
+goto loop
+:run
+python "%~dp0mock_fuseki.py" !PORT!
+'@ | Set-Content -Path (Join-Path $bundle 'tools/fuseki/fuseki-server.bat') -Encoding ascii
+          @"
+import json
+import sys
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import urlparse, parse_qs
+
+
+class Handler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        parsed = urlparse(self.path)
+        if parsed.path == '/$/ping':
+            self.send_response(200)
+            self.send_header('Content-Type', 'text/plain')
+            self.end_headers()
+            self.wfile.write(b'OK')
+        elif parsed.path == '/ds/sparql':
+            self.send_response(200)
+            self.send_header('Content-Type', 'application/sparql-results+json')
+            self.end_headers()
+            payload = {
+                'head': {'vars': ['count']},
+                'results': {'bindings': [{'count': {'type': 'literal', 'value': '1'}}]},
+            }
+            self.wfile.write(json.dumps(payload).encode('utf-8'))
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+    def log_message(self, *args):
+        return
+
+
+def main(port: int) -> None:
+    server = ThreadingHTTPServer(('127.0.0.1', port), Handler)
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+
+
+if __name__ == '__main__':
+    port = int(sys.argv[1]) if len(sys.argv) > 1 else 3030
+    main(port)
+"@ | Set-Content -Path (Join-Path $bundle 'tools/fuseki/mock_fuseki.py') -Encoding utf8
+      - name: Verify bundle checksums
+        shell: pwsh
+        run: dist/offline_bundle/scripts/bundle-verify.ps1 -Path dist/offline_bundle
+      - name: First run bootstrap
+        shell: pwsh
+        run: dist/offline_bundle/scripts/bundle-first-run.ps1 -Path dist/offline_bundle
+      - name: Start bundle server
+        shell: pwsh
+        run: dist/offline_bundle/scripts/bundle-start.ps1 -Path dist/offline_bundle
+      - name: Health probe
+        shell: pwsh
+        run: dist/offline_bundle/scripts/bundle-health.ps1 -Path dist/offline_bundle
+      - name: Stop server
+        shell: pwsh
+        run: dist/offline_bundle/scripts/bundle-stop.ps1 -Path dist/offline_bundle
+      - name: Upload offline bundle outputs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: offline-bundle
+          path: |
+            dist/offline_bundle/**
+            kg/reports/bundle-smoke.txt
   api-contract-tests:
     needs: [incremental-scan, inference-smoke]
     if: needs.incremental-scan.outputs.changed == 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,6 +74,10 @@ jobs:
             kg/canonical/release_notes.md
             kg/canonical/checksums.sha256
             dist/*.zip
+            dist/offline_bundle/**
             scripts/verify-release.ps1
+          body: |
+            Offline bundle directory (text only) is published as dist/offline_bundle/.
+            Replace offline_bundle.zip.PLACEHOLDER.txt with a deterministic ZIP (set SOURCE_DATE_EPOCH) before distributing binaries.
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/bundle/assembler/tdb2-readonly.ttl
+++ b/bundle/assembler/tdb2-readonly.ttl
@@ -1,0 +1,22 @@
+@prefix : <#> .
+@prefix fuseki: <http://jena.apache.org/fuseki#> .
+@prefix tdb2: <http://jena.hpl.hp.com/2008/tdb#> .
+@prefix ja: <http://jena.hpl.hp.com/2005/11/Assembler#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+
+[] rdf:type fuseki:Server ;
+   fuseki:services (
+      [ rdf:type fuseki:Service ;
+        fuseki:name              "ds" ;
+        fuseki:serviceQuery      "sparql" ;
+        fuseki:serviceReadGraphStore "get" ;
+        fuseki:serviceReadQuads  "quads" ;
+        fuseki:dataset           :dataset ;
+        fuseki:status            "readonly"
+      ]
+   ) .
+
+:dataset rdf:type tdb2:DatasetTDB2 ;
+    tdb2:location "file:./fuseki/databases/tdb2" ;
+    tdb2:unionDefaultGraph true ;
+    tdb2:requireWritePermission true .

--- a/bundle/config/bundle_config.yml
+++ b/bundle/config/bundle_config.yml
@@ -1,0 +1,16 @@
+version: 1
+fuseki:
+  host: 127.0.0.1
+  port: 3030
+  timeout_seconds: 120
+  jvm_opts: "-Xms512m -Xmx1024m"
+  log_dir: fuseki/logs
+  health_query: "SELECT (COUNT(*) AS ?count) WHERE { ?s ?p ?o } LIMIT 1"
+dataset:
+  assembler: fuseki/tdb2-readonly.ttl
+  location: fuseki/databases/tdb2
+  source:
+    nq: kg/dataset.nq
+    ttl: kg/dataset.ttl
+bootstrap:
+  first_run_marker: fuseki/databases/first_run.ok

--- a/bundle/scripts/bundle-first-run.ps1
+++ b/bundle/scripts/bundle-first-run.ps1
@@ -1,0 +1,129 @@
+param(
+    [string]$Path = $(Split-Path -Parent $PSScriptRoot)
+)
+
+$ErrorActionPreference = 'Stop'
+$bundleRoot = (Resolve-Path $Path).Path
+$scriptsDir = Join-Path $bundleRoot 'scripts'
+$configPath = Join-Path $bundleRoot 'config/bundle_config.yml'
+if (-not (Test-Path $configPath)) {
+    throw "Missing bundle_config.yml"
+}
+if (-not (Get-Command ConvertFrom-Yaml -ErrorAction SilentlyContinue)) {
+    throw 'PowerShell YAML support required (ConvertFrom-Yaml not available)'
+}
+$config = Get-Content $configPath -Raw | ConvertFrom-Yaml
+
+Write-Host 'Running bundle verification'
+& (Join-Path $scriptsDir 'bundle-verify.ps1') -Path $bundleRoot
+
+$javaCmd = 'java'
+if ($env:JAVA_HOME) {
+    $candidate = Join-Path $env:JAVA_HOME 'bin/java'
+    if (Test-Path $candidate) {
+        $javaCmd = $candidate
+    }
+}
+if (-not (Get-Command $javaCmd -ErrorAction SilentlyContinue)) {
+    throw 'Java runtime not found. Install a JDK and ensure java.exe is on PATH.'
+}
+
+$jenaHome = Join-Path $bundleRoot 'tools/jena'
+$fusekiHome = Join-Path $bundleRoot 'tools/fuseki'
+if (-not (Test-Path $jenaHome)) {
+    throw 'Apache Jena not found under tools/jena'
+}
+if (-not (Test-Path $fusekiHome)) {
+    throw 'Apache Jena Fuseki not found under tools/fuseki'
+}
+
+$loaderCandidates = @(
+    (Join-Path $jenaHome 'bat/tdb2_tdbloader.bat'),
+    (Join-Path $jenaHome 'bat/tdb2.tdbloader.bat'),
+    (Join-Path $jenaHome 'bin/tdb2_tdbloader'),
+    (Join-Path $jenaHome 'bin/tdb2.tdbloader')
+)
+$loader = $null
+foreach ($candidate in $loaderCandidates) {
+    if (Test-Path $candidate) {
+        $loader = $candidate
+        break
+    }
+}
+if ($env:EAR_BUNDLE_TDBLOADER) {
+    $loader = $env:EAR_BUNDLE_TDBLOADER
+}
+if (-not $loader) {
+    throw 'TDB loader script not found under tools/jena'
+}
+
+$datasetNq = Join-Path $bundleRoot $config.dataset.source.nq
+$datasetTtl = Join-Path $bundleRoot $config.dataset.source.ttl
+$dataset = $null
+if ($config.dataset.source.nq -and (Test-Path $datasetNq)) {
+    $dataset = $datasetNq
+} elseif ($config.dataset.source.ttl -and (Test-Path $datasetTtl)) {
+    $dataset = $datasetTtl
+}
+if (-not $dataset) {
+    throw 'No dataset source available (expected kg/dataset.nq or dataset.ttl)'
+}
+
+$tdbDir = Join-Path $bundleRoot $config.dataset.location
+New-Item -ItemType Directory -Path $tdbDir -Force | Out-Null
+$marker = $config.bootstrap.first_run_marker
+if (-not $marker) { $marker = 'fuseki/databases/first_run.ok' }
+$markerPath = Join-Path $bundleRoot $marker
+$needsLoad = -not (Test-Path $markerPath)
+
+if ($needsLoad) {
+    Write-Host 'Loading dataset into TDB2 store'
+    $existing = Get-ChildItem -Path $tdbDir -Force -ErrorAction SilentlyContinue
+    if ($existing) {
+        foreach ($item in $existing) {
+            Remove-Item -Path $item.FullName -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+    $loaderArgs = @('--loc', $tdbDir)
+    if ($dataset.ToLower().EndsWith('.nq')) {
+        $loaderArgs += '--nquads'
+    }
+    $loaderArgs += $dataset
+    if ($env:EAR_BUNDLE_TDBLOADER_ARGS) {
+        try {
+            $parsed = $env:EAR_BUNDLE_TDBLOADER_ARGS | ConvertFrom-Json
+            if ($parsed -is [System.Collections.IEnumerable]) {
+                $loaderArgs = @($parsed | ForEach-Object { [string]$_ })
+            } else {
+                $loaderArgs = @([string]$parsed)
+            }
+        } catch {
+            $loaderArgs = $env:EAR_BUNDLE_TDBLOADER_ARGS -split '\s+'
+        }
+    }
+    $proc = Start-Process -FilePath $loader -ArgumentList $loaderArgs -WorkingDirectory $bundleRoot -PassThru -Wait
+    if ($proc.ExitCode -ne 0) {
+        throw "TDB loader exited with code $($proc.ExitCode)"
+    }
+    Write-Host 'Dataset load completed'
+} else {
+    Write-Host 'TDB2 store already initialized; skipping load'
+}
+
+Write-Host 'Starting Fuseki for smoke test'
+& (Join-Path $scriptsDir 'bundle-start.ps1') -Path $bundleRoot | Out-Null
+& (Join-Path $scriptsDir 'bundle-health.ps1') -Path $bundleRoot -Quiet | Out-Null
+Write-Host 'Health check succeeded; stopping Fuseki'
+& (Join-Path $scriptsDir 'bundle-stop.ps1') -Path $bundleRoot | Out-Null
+
+$timestamp = Get-Date -Format 'yyyy-MM-ddTHH:mm:ssZ'
+New-Item -ItemType Directory -Path (Split-Path $markerPath) -Force | Out-Null
+$timestamp | Set-Content -Path $markerPath -Encoding utf8
+$reportPath = Join-Path $bundleRoot 'kg/reports/bundle-smoke.txt'
+$reportLines = @(
+    "timestamp=$timestamp",
+    "dataset=$([IO.Path]::GetFileName($dataset))",
+    "java=$javaCmd"
+)
+$reportLines | Set-Content -Path $reportPath -Encoding utf8
+Write-Host "First run complete. Marker written to $markerPath"

--- a/bundle/scripts/bundle-health.ps1
+++ b/bundle/scripts/bundle-health.ps1
@@ -1,0 +1,61 @@
+param(
+    [string]$Path = $(Split-Path -Parent $PSScriptRoot),
+    [int]$TimeoutSeconds = 60,
+    [switch]$Quiet
+)
+
+$ErrorActionPreference = 'Stop'
+$bundleRoot = (Resolve-Path $Path).Path
+$configPath = Join-Path $bundleRoot 'config/bundle_config.yml'
+if (-not (Test-Path $configPath)) {
+    throw "Missing bundle_config.yml"
+}
+
+if (-not (Get-Command ConvertFrom-Yaml -ErrorAction SilentlyContinue)) {
+    throw 'PowerShell YAML support required (ConvertFrom-Yaml not available)'
+}
+$config = Get-Content $configPath -Raw | ConvertFrom-Yaml
+$host = $config.fuseki.host
+$port = $config.fuseki.port
+$query = $config.fuseki.health_query
+if (-not $host) { $host = '127.0.0.1' }
+if (-not $port) { $port = 3030 }
+if (-not $query) { $query = 'SELECT * WHERE { ?s ?p ?o } LIMIT 1' }
+
+$base = "http://$host:$port"
+$ping = "$base/$/ping"
+$service = "$base/ds/sparql"
+$deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+$pingOk = $false
+while ((Get-Date) -lt $deadline) {
+    try {
+        $resp = Invoke-WebRequest -Uri $ping -UseBasicParsing -TimeoutSec 10
+        if ($resp.StatusCode -eq 200) {
+            $pingOk = $true
+            break
+        }
+    } catch {
+        Start-Sleep -Seconds 1
+    }
+}
+
+if (-not $pingOk) {
+    Write-Error "Fuseki ping endpoint unavailable at $ping"
+    exit 1
+}
+
+$encodedQuery = [System.Uri]::EscapeDataString($query)
+try {
+    $resp = Invoke-WebRequest -Uri "$service?query=$encodedQuery" -UseBasicParsing -TimeoutSec 30
+    if ($resp.StatusCode -ne 200) {
+        Write-Error "SPARQL query failed with status $($resp.StatusCode)"
+        exit 1
+    }
+} catch {
+    Write-Error "Failed to execute SPARQL query against $service"
+    exit 1
+}
+
+if (-not $Quiet) {
+    Write-Host "Fuseki service healthy at $service"
+}

--- a/bundle/scripts/bundle-start.ps1
+++ b/bundle/scripts/bundle-start.ps1
@@ -1,0 +1,106 @@
+param(
+    [string]$Path = $(Split-Path -Parent $PSScriptRoot),
+    [switch]$NoWait
+)
+
+$ErrorActionPreference = 'Stop'
+$bundleRoot = (Resolve-Path $Path).Path
+$configPath = Join-Path $bundleRoot 'config/bundle_config.yml'
+if (-not (Test-Path $configPath)) {
+    throw "Missing bundle_config.yml"
+}
+if (-not (Get-Command ConvertFrom-Yaml -ErrorAction SilentlyContinue)) {
+    throw 'PowerShell YAML support required (ConvertFrom-Yaml not available)'
+}
+$config = Get-Content $configPath -Raw | ConvertFrom-Yaml
+$host = $config.fuseki.host
+$port = $config.fuseki.port
+$timeout = $config.fuseki.timeout_seconds
+$jvmOpts = $config.fuseki.jvm_opts
+$logDirRel = $config.fuseki.log_dir
+if (-not $host) { $host = '127.0.0.1' }
+if (-not $port) { $port = 3030 }
+if (-not $timeout) { $timeout = 120 }
+if (-not $logDirRel) { $logDirRel = 'fuseki/logs' }
+
+$logDir = Join-Path $bundleRoot $logDirRel
+New-Item -ItemType Directory -Path $logDir -Force | Out-Null
+$pidFile = Join-Path $bundleRoot 'fuseki/server.pid'
+if (Test-Path $pidFile) {
+    throw "Existing Fuseki PID file detected at $pidFile"
+}
+
+$assembler = Join-Path $bundleRoot $config.dataset.assembler
+if (-not (Test-Path $assembler)) {
+    throw "Assembler not found: $assembler"
+}
+
+$env:FUSEKI_BASE = Join-Path $bundleRoot 'fuseki'
+$env:FUSEKI_HOME = $env:FUSEKI_BASE
+
+function Start-FusekiProcess {
+    param(
+        [string]$Executable,
+        [string[]]$Arguments
+    )
+    $startInfo = @{
+        FilePath = $Executable
+        ArgumentList = $Arguments
+        WorkingDirectory = $bundleRoot
+        PassThru = $true
+        RedirectStandardOutput = Join-Path $logDir 'fuseki.out.log'
+        RedirectStandardError = Join-Path $logDir 'fuseki.err.log'
+    }
+    return Start-Process @startInfo
+}
+
+$exe = $null
+$args = @()
+if ($env:EAR_BUNDLE_FUSEKI_CMD) {
+    $exe = $env:EAR_BUNDLE_FUSEKI_CMD
+    if ($env:EAR_BUNDLE_FUSEKI_ARGS) {
+        try {
+            $parsedArgs = $env:EAR_BUNDLE_FUSEKI_ARGS | ConvertFrom-Json
+            if ($parsedArgs -is [System.Collections.IEnumerable]) {
+                $args = @($parsedArgs | ForEach-Object { [string]$_ })
+            } else {
+                $args = @([string]$parsedArgs)
+            }
+        } catch {
+            $args = $env:EAR_BUNDLE_FUSEKI_ARGS -split '\s+'
+        }
+    }
+} else {
+    $fusekiCandidates = @(
+        (Join-Path $bundleRoot 'tools/fuseki/fuseki-server.bat'),
+        (Join-Path $bundleRoot 'tools/fuseki/fuseki-server')
+    )
+    foreach ($candidate in $fusekiCandidates) {
+        if (Test-Path $candidate) {
+            $exe = $candidate
+            break
+        }
+    }
+    if (-not $exe) {
+        throw 'Fuseki server script not found under tools/fuseki'
+    }
+    $args = @('--config', $assembler, '--port', $port, '--localhost')
+    if ($jvmOpts) {
+        $env:FUSEKI_JVM_ARGS = $jvmOpts
+    }
+}
+
+$process = Start-FusekiProcess -Executable $exe -Arguments $args
+$process.Id | Out-File -FilePath $pidFile -Encoding ascii -NoNewline
+
+if (-not $NoWait) {
+    $health = Join-Path $bundleRoot 'scripts/bundle-health.ps1'
+    try {
+        & $health -Path $bundleRoot -TimeoutSeconds $timeout -Quiet
+    } catch {
+        Write-Error "Fuseki failed to become healthy"
+        & (Join-Path $bundleRoot 'scripts/bundle-stop.ps1') -Path $bundleRoot | Out-Null
+        exit 1
+    }
+    Write-Host "Fuseki ready at http://$host:$port/ds"
+}

--- a/bundle/scripts/bundle-stop.ps1
+++ b/bundle/scripts/bundle-stop.ps1
@@ -1,0 +1,27 @@
+param(
+    [string]$Path = $(Split-Path -Parent $PSScriptRoot)
+)
+
+$ErrorActionPreference = 'Stop'
+$bundleRoot = (Resolve-Path $Path).Path
+$pidFile = Join-Path $bundleRoot 'fuseki/server.pid'
+if (-not (Test-Path $pidFile)) {
+    Write-Warning 'Fuseki PID file not found; server may not be running.'
+    return
+}
+$pidText = (Get-Content -Path $pidFile -Raw).Trim()
+$pidValue = 0
+if (-not [int]::TryParse($pidText, [ref]$pidValue)) {
+    Remove-Item -Path $pidFile -Force
+    throw "Invalid PID value: $pidText"
+}
+$pid = $pidValue
+try {
+    $proc = Get-Process -Id $pid -ErrorAction Stop
+    Stop-Process -Id $pid -ErrorAction Stop
+    $proc.WaitForExit()
+} catch {
+    Write-Warning "Process $pid not running"
+}
+Remove-Item -Path $pidFile -Force
+Write-Host "Fuseki stopped"

--- a/bundle/scripts/bundle-verify.ps1
+++ b/bundle/scripts/bundle-verify.ps1
@@ -1,0 +1,56 @@
+param(
+    [string]$Path = $(Split-Path -Parent $PSScriptRoot)
+)
+
+$ErrorActionPreference = 'Stop'
+$bundleRoot = Resolve-Path $Path
+$checksumFile = Join-Path $bundleRoot 'checksums.sha256'
+if (-not (Test-Path $checksumFile)) {
+    throw "checksums.sha256 not found in $bundleRoot"
+}
+
+$expected = [ordered]@{}
+$lines = Get-Content -Path $checksumFile | Where-Object { $_.Trim() -ne '' }
+foreach ($line in $lines) {
+    if ($line -match '^([0-9a-f]{64})\s+(.+)$') {
+        $expected[$Matches[2]] = $Matches[1].ToLower()
+    } else {
+        throw "Malformed checksum line: $line"
+    }
+}
+
+$errors = @()
+foreach ($entry in $expected.GetEnumerator()) {
+    $rel = $entry.Key
+    $hash = $entry.Value
+    $full = Join-Path $bundleRoot $rel
+    if (-not (Test-Path $full)) {
+        $errors += "Missing file: $rel"
+        continue
+    }
+    $actual = (Get-FileHash -Path $full -Algorithm SHA256).Hash.ToLower()
+    if ($actual -ne $hash) {
+        $errors += "Hash mismatch for $rel"
+    }
+}
+
+$allFiles = Get-ChildItem -Path $bundleRoot -Recurse -File | ForEach-Object {
+    [IO.Path]::GetRelativePath($bundleRoot, $_.FullName).Replace('\\', '/')
+} | Sort-Object -Unique
+$unexpected = @()
+foreach ($file in $allFiles) {
+    if (-not $expected.Contains($file)) {
+        $unexpected += $file
+    }
+}
+
+if ($unexpected) {
+    Write-Warning ("Unexpected files detected:" + [Environment]::NewLine + ($unexpected -join [Environment]::NewLine))
+}
+
+if ($errors) {
+    $errors | ForEach-Object { Write-Error $_ }
+    exit 1
+}
+
+Write-Host "Bundle verification OK"

--- a/bundle/static/LICENSES/NOTICE.txt
+++ b/bundle/static/LICENSES/NOTICE.txt
@@ -1,0 +1,7 @@
+EarCrawler Offline Bundle incorporates the following third-party projects:
+
+- Apache Jena (Apache-2.0)
+- Apache Jena Fuseki (Apache-2.0)
+- PowerShell scripts authored by the EarCrawler team (MIT)
+
+Refer to the main repository LICENSE file for project licensing details.

--- a/bundle/static/README_OFFLINE.md
+++ b/bundle/static/README_OFFLINE.md
@@ -1,0 +1,14 @@
+# Offline bundle quick start
+
+Welcome! This directory is a portable, read-only copy of the EarCrawler
+knowledge graph plus helper scripts. Follow these steps on the first run:
+
+1. Verify integrity with `scripts\bundle-verify.ps1`.
+2. Run `scripts\bundle-first-run.ps1` to validate the toolchain, load the TDB2
+   database, and execute smoke checks.
+3. Start the read-only Fuseki endpoint with `scripts\bundle-start.ps1`.
+4. When finished, stop the server using `scripts\bundle-stop.ps1`.
+
+Additional documentation lives in `docs/offline_bundle/usage.md` within the
+source repository. To create a deterministic ZIP, use an external archiver with
+`SOURCE_DATE_EPOCH` set and keep all timestamps fixed.

--- a/bundle/static/SBOM.cdx.json
+++ b/bundle/static/SBOM.cdx.json
@@ -1,0 +1,13 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5",
+  "version": 1,
+  "metadata": {
+    "component": {
+      "type": "application",
+      "name": "EarCrawler Offline Bundle",
+      "version": "0.0.0"
+    }
+  },
+  "components": []
+}

--- a/bundle/static/manifest.sig.PLACEHOLDER.txt
+++ b/bundle/static/manifest.sig.PLACEHOLDER.txt
@@ -1,0 +1,7 @@
+This file is a placeholder for the detached signature of `manifest.json` and
+`checksums.sha256`. Generate a real signature on the release machine:
+
+1. Ensure the release key is available in the local key store.
+2. Run `gpg --detach-sign --armor --output manifest.sig manifest.json`.
+3. Replace this placeholder with the resulting ASCII-armored signature before
+   distributing the bundle.

--- a/bundle/static/offline_bundle.zip.PLACEHOLDER.txt
+++ b/bundle/static/offline_bundle.zip.PLACEHOLDER.txt
@@ -1,0 +1,4 @@
+Binary ZIP archive omitted from source control. Create using a deterministic
+archiver (e.g., `powershell Compress-Archive` with pre-normalized timestamps) and
+replace this placeholder before publishing the release artifact. Ensure
+`SOURCE_DATE_EPOCH` is set so timestamps remain stable.

--- a/cli/__init__.py
+++ b/cli/__init__.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+from earCrawler.cli.__main__ import cli
+
+__all__ = ["cli"]

--- a/dist/offline_bundle/README_OFFLINE.md
+++ b/dist/offline_bundle/README_OFFLINE.md
@@ -1,0 +1,14 @@
+# Offline bundle quick start
+
+Welcome! This directory is a portable, read-only copy of the EarCrawler
+knowledge graph plus helper scripts. Follow these steps on the first run:
+
+1. Verify integrity with `scripts\bundle-verify.ps1`.
+2. Run `scripts\bundle-first-run.ps1` to validate the toolchain, load the TDB2
+   database, and execute smoke checks.
+3. Start the read-only Fuseki endpoint with `scripts\bundle-start.ps1`.
+4. When finished, stop the server using `scripts\bundle-stop.ps1`.
+
+Additional documentation lives in `docs/offline_bundle/usage.md` within the
+source repository. To create a deterministic ZIP, use an external archiver with
+`SOURCE_DATE_EPOCH` set and keep all timestamps fixed.

--- a/docs/offline_bundle/usage.md
+++ b/docs/offline_bundle/usage.md
@@ -1,0 +1,74 @@
+# Offline Bundle Usage Guide
+
+This document describes how to work with the portable offline bundle produced by
+`earctl bundle build`. The bundle is designed for Windows-first environments and
+keeps all execution local so it can run on networks without Internet access.
+
+## Preparing the bundle
+
+1. Run `earctl bundle build` on a machine that already has the canonical KG
+   artifacts under `kg/canonical`.
+2. Copy `dist/offline_bundle/` to the target machine. When distributing the
+   bundle externally, zip the directory with deterministic timestamps
+   (`SOURCE_DATE_EPOCH`) and publish a detached signature for
+   `checksums.sha256`.
+3. Review `README_OFFLINE.md` inside the bundle for a condensed quick-start.
+
+## Verifying integrity
+
+On the target machine open PowerShell and run:
+
+```powershell
+cd path\to\offline_bundle
+scripts\bundle-verify.ps1
+```
+
+The script recomputes SHA256 digests for every file listed in
+`checksums.sha256`. It also warns about unexpected files or missing entries. The
+bundle should not be modified before verification. Signature validation is
+performed separately using the instructions in `manifest.sig.PLACEHOLDER.txt`.
+
+## First run bootstrap
+
+`bundle-first-run.ps1` performs the heavy lifting required for first use:
+
+* Validates that Java, Apache Jena, and Apache Jena Fuseki are installed under
+  `tools/` (created by the hermetic bootstrap scripts from B.15).
+* Runs `scripts/bundle-verify.ps1` to ensure the payload is intact.
+* Loads the canonical dataset (`kg/dataset.nq`) into a read-only TDB2 store at
+  `fuseki/databases/tdb2` using `tdb2_tdbloader.bat`.
+* Starts the Fuseki server with the read-only `/ds` service and executes a
+  health probe plus a sample SPARQL query.
+* Stops the server and writes `fuseki/databases/first_run.ok` along with a smoke
+  report at `kg/reports/bundle-smoke.txt`.
+
+The script is idempotent. If `first_run.ok` already exists it skips the loading
+step and just performs verification and health checks.
+
+## Operating the server
+
+After the first run the bundle can be started or stopped with:
+
+```powershell
+scripts\bundle-start.ps1
+scripts\bundle-stop.ps1
+```
+
+`bundle-start.ps1` blocks until the `/ds` endpoint responds to `/$/ping` and a
+`SELECT` query. `bundle-health.ps1` can be used independently for periodic
+checks while the server is running.
+
+To stop the server run `scripts\bundle-stop.ps1`. It reads the PID recorded by
+`bundle-start.ps1`, sends a termination signal, and removes the PID file once
+shutdown completes.
+
+## Upgrading to a new release
+
+1. Run `earctl bundle build` on a trusted machine.
+2. Verify the new bundle with `scripts\bundle-verify.ps1`.
+3. Stop the existing Fuseki instance.
+4. Replace the old bundle directory with the freshly built one.
+5. Run `scripts\bundle-first-run.ps1` to perform a sanity check.
+
+Previous smoke reports remain in `kg/reports/`. Garbage collection retains
+recent bundles for 90 days (see `earctl gc`).

--- a/earCrawler/cli/__main__.py
+++ b/earCrawler/cli/__main__.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 """Top-level CLI exposing NSF parser and reports commands."""
 
+import importlib
 import json
 import platform
 import sys
@@ -99,6 +100,8 @@ cli.add_command(auth)
 cli.add_command(policy_cmd, name="policy")
 cli.add_command(audit)
 cli.add_command(perf.perf, name="perf")
+bundle_cli = importlib.import_module("earCrawler.cli.bundle")
+cli.add_command(bundle_cli.bundle, name="bundle")
 
 @cli.command(name="crawl")
 @click.option(

--- a/earCrawler/cli/bundle.py
+++ b/earCrawler/cli/bundle.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import click
+
+from earCrawler.security import policy
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def _pwsh() -> str:
+    shell = shutil.which("pwsh") or shutil.which("powershell")
+    if not shell:
+        raise click.ClickException("PowerShell (pwsh) is required for bundle commands")
+    return shell
+
+
+def _run_ps(script: Path, *args: str) -> None:
+    cmd = [_pwsh(), "-File", str(script)] + list(args)
+    completed = subprocess.run(cmd, check=False)
+    if completed.returncode != 0:
+        raise click.ClickException(f"Command failed with exit code {completed.returncode}: {' '.join(cmd)}")
+
+
+@click.group()
+@policy.require_role("operator", "maintainer")
+@policy.enforce
+def bundle() -> None:
+    """Offline bundle helpers."""
+
+
+@bundle.command()
+@click.option("--canonical", type=click.Path(path_type=Path), default=Path("kg/canonical"))
+def build(canonical: Path) -> None:
+    """Build the offline bundle under dist/offline_bundle."""
+    repo = _repo_root()
+    script = repo / "scripts" / "build-offline-bundle.ps1"
+    args = ["-CanonicalDir", str(canonical)] if canonical != Path("kg/canonical") else []
+    _run_ps(script, *args)
+
+
+@bundle.command()
+@click.option("--path", type=click.Path(path_type=Path), default=Path("dist/offline_bundle"))
+def verify(path: Path) -> None:
+    """Verify bundle checksums."""
+    script = path / "scripts" / "bundle-verify.ps1"
+    if not script.exists():
+        raise click.ClickException(f"Verification script not found under {script.parent}")
+    _run_ps(script, "-Path", str(path))
+
+
+@bundle.command()
+@click.option("--path", type=click.Path(path_type=Path), default=Path("dist/offline_bundle"))
+def smoke(path: Path) -> None:
+    """Run first-run bootstrap smoke test."""
+    script = path / "scripts" / "bundle-first-run.ps1"
+    if not script.exists():
+        raise click.ClickException(f"First-run script not found under {script.parent}")
+    _run_ps(script, "-Path", str(path))

--- a/earCrawler/cli/gc.py
+++ b/earCrawler/cli/gc.py
@@ -17,7 +17,7 @@ from earCrawler.security import policy
 @click.option("--yes", is_flag=True, help="Confirm deletions without prompt.")
 @click.option(
     "--target",
-    type=click.Choice(["telemetry", "cache", "kg", "audit", "all"]),
+    type=click.Choice(["telemetry", "cache", "kg", "audit", "bundle", "all"]),
     default="all",
 )
 @click.option("--max-age", type=int, default=None, help="Override max age in days.")

--- a/earCrawler/utils/retention.py
+++ b/earCrawler/utils/retention.py
@@ -162,6 +162,7 @@ DEFAULT_POLICIES = {
     "cache": RetentionPolicy(max_days=30, max_total_mb=512, max_file_mb=64, keep_last_n=10),
     "kg": RetentionPolicy(max_days=30, max_total_mb=1024, max_file_mb=256, keep_last_n=10),
     "audit": RetentionPolicy(max_days=30, max_total_mb=256, max_file_mb=8, keep_last_n=10),
+    "bundle": RetentionPolicy(max_days=90, max_total_mb=4096, max_file_mb=512, keep_last_n=3),
 }
 
 
@@ -173,7 +174,7 @@ def run_gc(
     max_file_mb: int | None = None,
     keep_last_n: int | None = None,
 ) -> dict:
-    targets = ["telemetry", "cache", "kg", "audit"] if target == "all" else [target]
+    targets = ["telemetry", "cache", "kg", "audit", "bundle"] if target == "all" else [target]
     all_candidates: List[dict] = []
     errors: List[str] = []
     policies: dict[str, dict] = {}
@@ -200,6 +201,9 @@ def run_gc(
         "audit": [
             Path(os.getenv("APPDATA") or str(Path.home())) / "EarCrawler" / "audit",
             Path(os.getenv("PROGRAMDATA") or (os.getenv("APPDATA") or str(Path.home()))) / "EarCrawler" / "audit",
+        ],
+        "bundle": [
+            Path("dist/offline_bundle"),
         ],
     }
 

--- a/kg/canonical/dataset.nq
+++ b/kg/canonical/dataset.nq
@@ -1,0 +1,2 @@
+<http://example.org/bundle> <http://example.org/contains> <http://example.org/dataset> <http://example.org/graph> .
+<http://example.org/dataset> <http://purl.org/dc/terms/title> "Sample canonical dataset" <http://example.org/graph> .

--- a/kg/canonical/dataset.ttl
+++ b/kg/canonical/dataset.ttl
@@ -1,0 +1,5 @@
+@prefix ex: <http://example.org/> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+
+ex:bundle ex:contains ex:dataset .
+ex:dataset dcterms:title "Sample canonical dataset" .

--- a/kg/canonical/provenance.json
+++ b/kg/canonical/provenance.json
@@ -1,0 +1,10 @@
+{
+  "version": "0.20.0",
+  "source": "sample",
+  "artifacts": [
+    {
+      "path": "dataset.ttl",
+      "hash": "dummy"
+    }
+  ]
+}

--- a/kg/canonical/reports/summary.json
+++ b/kg/canonical/reports/summary.json
@@ -1,0 +1,4 @@
+{
+  "generated": "offline-sample",
+  "triples": 2
+}

--- a/kg/canonical/snapshots/count.srj
+++ b/kg/canonical/snapshots/count.srj
@@ -1,0 +1,8 @@
+{
+  "head": {"vars": ["count"]},
+  "results": {
+    "bindings": [
+      {"count": {"type": "literal", "value": "2"}}
+    ]
+  }
+}

--- a/kg/canonical/versions.json
+++ b/kg/canonical/versions.json
@@ -1,0 +1,7 @@
+{
+  "tools": {
+    "jena": "5.3.0",
+    "fuseki": "5.3.0"
+  },
+  "tools_sha256": "placeholder"
+}

--- a/scripts/build-offline-bundle.ps1
+++ b/scripts/build-offline-bundle.ps1
@@ -1,0 +1,125 @@
+param(
+    [string]$CanonicalDir = "kg/canonical",
+    [string]$OutputDir = "dist/offline_bundle"
+)
+
+$ErrorActionPreference = 'Stop'
+$repoRoot = Resolve-Path (Join-Path $PSScriptRoot '..')
+$canonicalPath = Join-Path $repoRoot $CanonicalDir
+if (-not (Test-Path $canonicalPath)) {
+    throw "Canonical directory not found: $CanonicalDir"
+}
+
+$requiredFiles = @('dataset.nq', 'dataset.ttl', 'provenance.json')
+foreach ($file in $requiredFiles) {
+    $path = Join-Path $canonicalPath $file
+    if (-not (Test-Path $path)) {
+        throw "Missing canonical artifact: $file"
+    }
+}
+
+$bundleRoot = Join-Path $repoRoot $OutputDir
+if (Test-Path $bundleRoot) {
+    Remove-Item -Path $bundleRoot -Recurse -Force
+}
+New-Item -ItemType Directory -Path $bundleRoot | Out-Null
+
+function Copy-Tree([string]$from, [string]$to) {
+    if (-not (Test-Path $from)) { return }
+    New-Item -ItemType Directory -Path $to -Force | Out-Null
+    Get-ChildItem -Path $from -Force | ForEach-Object {
+        $destination = Join-Path $to $_.Name
+        if ($_.PsIsContainer) {
+            Copy-Tree -from $_.FullName -to $destination
+        } else {
+            Copy-Item -Path $_.FullName -Destination $destination -Force
+        }
+    }
+}
+
+# Copy canonical KG
+Copy-Tree -from $canonicalPath -to (Join-Path $bundleRoot 'kg')
+
+# Copy Fuseki assembler and config
+Copy-Item -Path (Join-Path $repoRoot 'bundle/assembler/tdb2-readonly.ttl') `
+    -Destination (Join-Path $bundleRoot 'fuseki/tdb2-readonly.ttl') -Force
+Copy-Tree -from (Join-Path $repoRoot 'bundle/config') -to (Join-Path $bundleRoot 'config')
+
+# Copy scripts
+Copy-Tree -from (Join-Path $repoRoot 'bundle/scripts') -to (Join-Path $bundleRoot 'scripts')
+
+# Copy static files
+Copy-Tree -from (Join-Path $repoRoot 'bundle/static') -to $bundleRoot
+
+# Ensure directories required by runtime exist
+New-Item -ItemType Directory -Path (Join-Path $bundleRoot 'fuseki/databases') -Force | Out-Null
+New-Item -ItemType Directory -Path (Join-Path $bundleRoot 'fuseki/logs') -Force | Out-Null
+New-Item -ItemType Directory -Path (Join-Path $bundleRoot 'kg/reports') -Force | Out-Null
+
+# Write VERSION.txt
+$pyproject = Get-Content (Join-Path $repoRoot 'pyproject.toml')
+$versionLine = $pyproject | Where-Object { $_ -match '^version\s*=\s*"' } | Select-Object -First 1
+if (-not $versionLine) { throw 'Unable to determine project version' }
+$version = ($versionLine -split '"')[1]
+$commit = (git -C $repoRoot rev-parse HEAD).Trim()
+$versionContent = @(
+    "Version: $version",
+    "Commit: $commit"
+)
+$versionContent | Set-Content -Path (Join-Path $bundleRoot 'VERSION.txt') -Encoding utf8
+
+# Update SBOM component version
+$sbomPath = Join-Path $bundleRoot 'SBOM.cdx.json'
+if (Test-Path $sbomPath) {
+    $sbom = Get-Content $sbomPath -Raw | ConvertFrom-Json
+    if ($sbom.metadata -and $sbom.metadata.component) {
+        $sbom.metadata.component.version = $version
+    }
+    $sbom | ConvertTo-Json -Depth 10 | Set-Content -Path $sbomPath -Encoding utf8
+}
+
+# Generate manifest
+$sourceEpoch = $env:SOURCE_DATE_EPOCH
+if (-not $sourceEpoch) { $sourceEpoch = 946684800 }
+$timestamp = [DateTimeOffset]::FromUnixTimeSeconds([int64]$sourceEpoch).UtcDateTime.ToString('yyyy-MM-ddTHH:mm:ssZ')
+
+$files = Get-ChildItem -Path $bundleRoot -Recurse -File | Sort-Object { $_.FullName }
+$manifestEntries = @()
+$checksumLines = @()
+foreach ($file in $files) {
+    $relative = [IO.Path]::GetRelativePath($bundleRoot, $file.FullName).Replace('\\', '/')
+    $hash = (Get-FileHash -Path $file.FullName -Algorithm SHA256).Hash.ToLower()
+    $manifestEntries += [ordered]@{
+        path = $relative
+        size = $file.Length
+        sha256 = $hash
+    }
+    $checksumLines += "$hash  $relative"
+}
+
+$manifest = [ordered]@{
+    version = $version
+    commit = $commit
+    generated = $timestamp
+    files = $manifestEntries
+}
+$manifest | ConvertTo-Json -Depth 5 | Set-Content -Path (Join-Path $bundleRoot 'manifest.json') -Encoding utf8
+$checksumLines | Set-Content -Path (Join-Path $bundleRoot 'checksums.sha256') -Encoding ascii
+
+# Ensure signature placeholder exists
+$signaturePath = Join-Path $bundleRoot 'manifest.sig.PLACEHOLDER.txt'
+if (-not (Test-Path $signaturePath)) {
+    'Placeholder for detached signature.' | Set-Content -Path $signaturePath -Encoding utf8
+}
+
+# Copy provenance explicitly (should already exist under kg/)
+$provSrc = Join-Path $canonicalPath 'provenance.json'
+Copy-Item -Path $provSrc -Destination (Join-Path $bundleRoot 'provenance.json') -Force
+
+# Create smoke report placeholder if not present
+$smoke = Join-Path $bundleRoot 'kg/reports/bundle-smoke.txt'
+if (-not (Test-Path $smoke)) {
+    "Smoke test pending" | Set-Content -Path $smoke -Encoding utf8
+}
+
+Write-Host "Offline bundle staged at $bundleRoot"

--- a/security/policy.yml
+++ b/security/policy.yml
@@ -16,6 +16,7 @@ commands:
   fetch-entities: ["operator"]
   fetch-ear: ["operator"]
   warm-cache: ["operator"]
+  bundle: ["operator", "maintainer"]
 overrides:
   test_admin:
     roles: ["admin"]

--- a/tests/bundle/test_first_run_logic.py
+++ b/tests/bundle/test_first_run_logic.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import os
+import shutil
+import stat
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+BUILD_SCRIPT = ROOT / "scripts" / "build-offline-bundle.ps1"
+FIRST_RUN_SCRIPT = ROOT / "dist" / "offline_bundle" / "scripts" / "bundle-first-run.ps1"
+
+pytestmark = pytest.mark.skipif(shutil.which("pwsh") is None, reason="PowerShell required")
+
+
+def _run_build() -> Path:
+    subprocess.run(["pwsh", "-File", str(BUILD_SCRIPT)], check=True, cwd=ROOT)
+    return ROOT / "dist" / "offline_bundle"
+
+
+def _write_executable(path: Path, content: str) -> None:
+    path.write_text(content)
+    mode = path.stat().st_mode
+    path.chmod(mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+
+def test_first_run_bootstrap(tmp_path):
+    bundle = _run_build()
+
+    tools_jena = bundle / "tools" / "jena" / "bin"
+    tools_jena.mkdir(parents=True, exist_ok=True)
+    loader = tools_jena / "tdb2_tdbloader"
+    _write_executable(
+        loader,
+        """#!/usr/bin/env python3
+import argparse
+import pathlib
+parser = argparse.ArgumentParser()
+parser.add_argument('--loc', required=True)
+parser.add_argument('--nquads', action='store_true')
+parser.add_argument('dataset')
+args = parser.parse_args()
+path = pathlib.Path(args.loc)
+path.mkdir(parents=True, exist_ok=True)
+(path / 'loader.ok').write_text('loaded')
+""",
+    )
+
+    tools_fuseki = bundle / "tools" / "fuseki"
+    tools_fuseki.mkdir(parents=True, exist_ok=True)
+    fuseki = tools_fuseki / "fuseki-server"
+    _write_executable(
+        fuseki,
+        """#!/usr/bin/env python3
+import json
+import sys
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+class Handler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        if self.path.startswith('/$/ping'):
+            self.send_response(200)
+            self.send_header('Content-Type', 'text/plain')
+            self.end_headers()
+            self.wfile.write(b'OK')
+        elif self.path.startswith('/ds/sparql'):
+            self.send_response(200)
+            self.send_header('Content-Type', 'application/sparql-results+json')
+            self.end_headers()
+            payload = {
+                'head': {'vars': ['count']},
+                'results': {'bindings': [{'count': {'type': 'literal', 'value': '1'}}]},
+            }
+            self.wfile.write(json.dumps(payload).encode('utf-8'))
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+    def log_message(self, *args, **kwargs):
+        return
+
+def main(port: int) -> None:
+    server = ThreadingHTTPServer(('127.0.0.1', port), Handler)
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+
+if __name__ == '__main__':
+    port = 3030
+    for idx, value in enumerate(sys.argv):
+        if value == '--port' and idx + 1 < len(sys.argv):
+            port = int(sys.argv[idx + 1])
+    main(port)
+""",
+    )
+
+    # Provide fake java on PATH
+    fake_java_dir = tmp_path / "bin"
+    fake_java_dir.mkdir()
+    fake_java = fake_java_dir / "java"
+    _write_executable(fake_java, "#!/usr/bin/env python3\nprint('java version ""0""')\n")
+
+    env = os.environ.copy()
+    env["PATH"] = str(fake_java_dir) + os.pathsep + env.get("PATH", "")
+
+    subprocess.run(["pwsh", "-File", str(FIRST_RUN_SCRIPT), "-Path", str(bundle)], check=True, env=env, cwd=ROOT)
+    marker = bundle / "fuseki" / "databases" / "first_run.ok"
+    assert marker.exists()
+    report = bundle / "kg" / "reports" / "bundle-smoke.txt"
+    contents = report.read_text().splitlines()
+    assert any(line.startswith("timestamp=") for line in contents)
+
+    # Idempotent second run
+    subprocess.run(["pwsh", "-File", str(FIRST_RUN_SCRIPT), "-Path", str(bundle)], check=True, env=env, cwd=ROOT)
+    assert marker.read_text().strip()
+    assert (bundle / "fuseki" / "databases" / "tdb2" / "loader.ok").exists()

--- a/tests/bundle/test_health_script.py
+++ b/tests/bundle/test_health_script.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import json
+import shutil
+import socket
+import subprocess
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+HEALTH_SCRIPT = ROOT / "bundle" / "scripts" / "bundle-health.ps1"
+
+pytestmark = pytest.mark.skipif(shutil.which("pwsh") is None, reason="PowerShell required")
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+class _Handler(BaseHTTPRequestHandler):
+    ok = True
+
+    def do_GET(self):
+        if self.path.startswith("/$/ping"):
+            if self.ok:
+                self.send_response(200)
+                self.send_header("Content-Type", "text/plain")
+                self.end_headers()
+                self.wfile.write(b"OK")
+            else:
+                self.send_response(500)
+                self.end_headers()
+        elif self.path.startswith("/ds/sparql"):
+            self.send_response(200)
+            self.send_header("Content-Type", "application/sparql-results+json")
+            self.end_headers()
+            payload = {
+                "head": {"vars": ["count"]},
+                "results": {"bindings": [{"count": {"type": "literal", "value": "1"}}]},
+            }
+            self.wfile.write(json.dumps(payload).encode("utf-8"))
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+    def log_message(self, *args):
+        return
+
+
+def _start_server(port: int, ok: bool = True) -> ThreadingHTTPServer:
+    _Handler.ok = ok
+    server = ThreadingHTTPServer(("127.0.0.1", port), _Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server
+
+
+def _write_config(tmp: Path, port: int) -> None:
+    (tmp / "config").mkdir(parents=True, exist_ok=True)
+    config_text = f"""
+version: 1
+fuseki:
+  host: 127.0.0.1
+  port: {port}
+  timeout_seconds: 5
+  log_dir: fuseki/logs
+  jvm_opts: ""
+  health_query: "SELECT (COUNT(*) AS ?count) WHERE {{ ?s ?p ?o }} LIMIT 1"
+dataset:
+  assembler: fuseki/tdb2-readonly.ttl
+"""
+    (tmp / "config" / "bundle_config.yml").write_text(config_text.strip())
+
+
+def test_health_success(tmp_path):
+    port = _free_port()
+    server = _start_server(port, ok=True)
+    try:
+        _write_config(tmp_path, port)
+        subprocess.run(["pwsh", "-File", str(HEALTH_SCRIPT), "-Path", str(tmp_path)], check=True)
+    finally:
+        server.shutdown()
+
+
+def test_health_failure(tmp_path):
+    port = _free_port()
+    _write_config(tmp_path, port)
+    with pytest.raises(subprocess.CalledProcessError):
+        subprocess.run(["pwsh", "-File", str(HEALTH_SCRIPT), "-Path", str(tmp_path), "-TimeoutSeconds", "2"], check=True)

--- a/tests/bundle/test_manifest_and_verify.py
+++ b/tests/bundle/test_manifest_and_verify.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+BUILD_SCRIPT = ROOT / "scripts" / "build-offline-bundle.ps1"
+VERIFY_SCRIPT = ROOT / "dist" / "offline_bundle" / "scripts" / "bundle-verify.ps1"
+
+pytestmark = pytest.mark.skipif(shutil.which("pwsh") is None, reason="PowerShell required")
+
+
+def run_build(tmp_env: dict[str, str] | None = None) -> Path:
+    subprocess.run(["pwsh", "-File", str(BUILD_SCRIPT)], check=True, cwd=ROOT, env=tmp_env)
+    return ROOT / "dist" / "offline_bundle"
+
+
+def test_manifest_sorted_and_verify(tmp_path):
+    bundle = run_build(None)
+    manifest_path = bundle / "manifest.json"
+    data = json.loads(manifest_path.read_text())
+    paths = [entry["path"] for entry in data["files"]]
+    assert paths == sorted(paths)
+    assert all(len(entry["sha256"]) == 64 for entry in data["files"])
+
+    checksums = (bundle / "checksums.sha256").read_text().splitlines()
+    sorted_lines = sorted(line for line in checksums if line.strip())
+    assert checksums == sorted_lines
+
+    subprocess.run(["pwsh", "-File", str(bundle / "scripts" / "bundle-verify.ps1"), "-Path", str(bundle)], check=True, cwd=ROOT)
+
+    # determinism: rebuild and ensure manifest unchanged
+    manifest_copy = manifest_path.read_text()
+    bundle = run_build(None)
+    assert manifest_path.read_text() == manifest_copy
+
+

--- a/tests/cli/test_bundle_commands.py
+++ b/tests/cli/test_bundle_commands.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from earCrawler.cli import bundle as bundle_cli
+from earCrawler.cli.__main__ import cli
+
+
+def test_bundle_command_rbac(monkeypatch):
+    calls: list[tuple[Path, tuple[str, ...]]] = []
+
+    def fake_run(script: Path, *args: str) -> None:
+        calls.append((script, args))
+
+    monkeypatch.setattr(bundle_cli, "_run_ps", fake_run)
+
+    runner = CliRunner()
+    res = runner.invoke(cli, ["bundle", "build"], env={"EARCTL_USER": "test_operator"})
+    assert res.exit_code == 0
+    assert calls and calls[0][0].name == "build-offline-bundle.ps1"
+
+    res = runner.invoke(cli, ["bundle", "build"], env={"EARCTL_USER": "test_reader"})
+    assert res.exit_code != 0
+
+
+def test_bundle_verify_and_smoke(monkeypatch, tmp_path):
+    calls: list[tuple[Path, tuple[str, ...]]] = []
+
+    def fake_run(script: Path, *args: str) -> None:
+        calls.append((script, args))
+
+    monkeypatch.setattr(bundle_cli, "_run_ps", fake_run)
+    runner = CliRunner()
+    env = {"EARCTL_USER": "test_operator"}
+    bundle_dir = tmp_path / "bundle"
+    scripts_dir = bundle_dir / "scripts"
+    scripts_dir.mkdir(parents=True, exist_ok=True)
+    for name in ("bundle-verify.ps1", "bundle-first-run.ps1"):
+        (scripts_dir / name).write_text("echo")
+
+    res = runner.invoke(cli, ["bundle", "verify", "--path", str(bundle_dir)], env=env)
+    assert res.exit_code == 0
+    assert calls[0][0].name == "bundle-verify.ps1"
+    assert calls[0][1] == ("-Path", str(bundle_dir))
+
+    custom_root = tmp_path / "custom"
+    custom_scripts = custom_root / "scripts"
+    custom_scripts.mkdir(parents=True, exist_ok=True)
+    (custom_scripts / "bundle-first-run.ps1").write_text("echo")
+
+    res = runner.invoke(cli, ["bundle", "smoke", "--path", str(custom_root)], env=env)
+    assert res.exit_code == 0
+    assert calls[1][0].name == "bundle-first-run.ps1"
+    assert calls[1][1] == ("-Path", str(custom_root))


### PR DESCRIPTION
## Summary
- add a read-only Fuseki assembler, bundle configuration, static documentation, and a deterministic build script that stages canonical data and produces manifest and checksum outputs with signing placeholders
- provide PowerShell tooling for bundle verification, first-run bootstrap, lifecycle management, and health probing alongside new CLI commands gated by RBAC to drive the offline bundle flow
- update CI, release packaging, retention policy, and security policy to exercise and retain the offline bundle while documenting usage and shipping a minimal canonical dataset and regression tests

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68cb23d425bc8325b5ed504c0f7249cd