### PR TITLE
Fix bundle bootstrap loader invocation and manifest ordering

### DIFF
--- a/bundle/scripts/bundle-first-run.ps1
+++ b/bundle/scripts/bundle-first-run.ps1
@@ -10,6 +10,7 @@ if (-not (Test-Path $configPath)) {
     throw "Missing bundle_config.yml"
 }
 . (Join-Path $PSScriptRoot 'bundle-config.ps1')
+. (Join-Path $PSScriptRoot 'bundle-process.ps1')
 $config = Import-BundleConfig -Path $configPath
 
 Write-Host 'Running bundle verification'
@@ -99,9 +100,9 @@ if ($needsLoad) {
             $loaderArgs = $env:EAR_BUNDLE_TDBLOADER_ARGS -split '\s+'
         }
     }
-    $proc = Start-Process -FilePath $loader -ArgumentList $loaderArgs -WorkingDirectory $bundleRoot -PassThru -Wait
-    if ($proc.ExitCode -ne 0) {
-        throw "TDB loader exited with code $($proc.ExitCode)"
+    $exitCode = Invoke-BundleProcess -Executable $loader -Arguments $loaderArgs -WorkingDirectory $bundleRoot
+    if ($exitCode -ne 0) {
+        throw "TDB loader exited with code $exitCode"
     }
     Write-Host 'Dataset load completed'
 } else {

--- a/bundle/scripts/bundle-process.ps1
+++ b/bundle/scripts/bundle-process.ps1
@@ -1,0 +1,215 @@
+function Resolve-BundleCommand {
+    param(
+        [Parameter(Mandatory = $true)][string]$Executable,
+        [string[]]$Arguments = @(),
+        [string]$WorkingDirectory = $null
+    )
+
+    $argumentList = @()
+    if ($Arguments) {
+        $argumentList = @($Arguments | ForEach-Object { [string]$_ })
+    }
+
+    if (-not $IsWindows) {
+        return [PSCustomObject]@{
+            FilePath     = $Executable
+            ArgumentList = $argumentList
+        }
+    }
+
+    $extension = [System.IO.Path]::GetExtension($Executable)
+    if ($extension) {
+        $normalized = $extension.ToLowerInvariant()
+        if (@('.exe', '.com', '.bat', '.cmd') -contains $normalized) {
+            return [PSCustomObject]@{
+                FilePath     = $Executable
+                ArgumentList = $argumentList
+            }
+        }
+    }
+
+    $resolvedExecutable = $Executable
+    if (-not (Test-Path $resolvedExecutable)) {
+        if ($WorkingDirectory) {
+            $candidate = Join-Path $WorkingDirectory $Executable
+            if (Test-Path $candidate) {
+                $resolvedExecutable = (Resolve-Path $candidate).Path
+            }
+        }
+    } else {
+        $resolvedExecutable = (Resolve-Path $resolvedExecutable).Path
+    }
+
+    if (-not (Test-Path $resolvedExecutable)) {
+        return [PSCustomObject]@{
+            FilePath     = $Executable
+            ArgumentList = $argumentList
+        }
+    }
+
+    $shebangLine = $null
+    try {
+        $shebangLine = Get-Content -Path $resolvedExecutable -TotalCount 1 -ErrorAction Stop
+    } catch {
+        $shebangLine = $null
+    }
+
+    if (-not $shebangLine -or $shebangLine -notmatch '^#!\s*(.+)$') {
+        return [PSCustomObject]@{
+            FilePath     = $Executable
+            ArgumentList = $argumentList
+        }
+    }
+
+    $commandLine = $Matches[1].Trim()
+    if (-not $commandLine) {
+        return [PSCustomObject]@{
+            FilePath     = $Executable
+            ArgumentList = $argumentList
+        }
+    }
+
+    $tokens = @()
+    $buffer = ''
+    $inQuotes = $false
+    for ($i = 0; $i -lt $commandLine.Length; $i++) {
+        $char = $commandLine[$i]
+        if ($char -eq '"') {
+            $inQuotes = -not $inQuotes
+            continue
+        }
+        if (-not $inQuotes -and [char]::IsWhiteSpace($char)) {
+            if ($buffer.Length -gt 0) {
+                $tokens += $buffer
+                $buffer = ''
+            }
+            continue
+        }
+        $buffer += $char
+    }
+    if ($buffer.Length -gt 0) {
+        $tokens += $buffer
+    }
+
+    if (-not $tokens -or $tokens.Count -eq 0) {
+        return [PSCustomObject]@{
+            FilePath     = $Executable
+            ArgumentList = $argumentList
+        }
+    }
+
+    $cmd = $tokens[0]
+    $cmdArgs = @()
+    if ($tokens.Count -gt 1) {
+        $cmdArgs = $tokens[1..($tokens.Count - 1)]
+    }
+
+    if ([System.IO.Path]::GetFileName($cmd).ToLowerInvariant() -eq 'env' -and $cmdArgs.Count -ge 1) {
+        $cmd = $cmdArgs[0]
+        if ($cmdArgs.Count -gt 1) {
+            $cmdArgs = $cmdArgs[1..($cmdArgs.Count - 1)]
+        } else {
+            $cmdArgs = @()
+        }
+    }
+
+    if ($cmd -eq 'python3' -and -not (Get-Command 'python3' -ErrorAction SilentlyContinue)) {
+        if (Get-Command 'python' -ErrorAction SilentlyContinue) {
+            $cmd = 'python'
+        }
+    }
+
+    if (-not (Get-Command $cmd -ErrorAction SilentlyContinue)) {
+        throw "Interpreter '$cmd' not found for executable '$Executable'"
+    }
+
+    $mergedArgs = @()
+    if ($cmdArgs) { $mergedArgs += $cmdArgs }
+    $mergedArgs += $resolvedExecutable
+    if ($argumentList) { $mergedArgs += $argumentList }
+
+    return [PSCustomObject]@{
+        FilePath     = $cmd
+        ArgumentList = @($mergedArgs | ForEach-Object { [string]$_ })
+    }
+}
+
+function Format-BundleArgumentList {
+    param(
+        [string[]]$Arguments = @()
+    )
+
+    if (-not $Arguments -or $Arguments.Count -eq 0) {
+        return $null
+    }
+
+    $quoted = @()
+    foreach ($argument in $Arguments) {
+        if ($null -eq $argument) { continue }
+        $stringArgument = [string]$argument
+        try {
+            $quoted += [System.Management.Automation.Language.CodeGeneration]::QuoteArgument($stringArgument)
+        } catch {
+            $escaped = $stringArgument.Replace('"', '\"')
+            $quoted += '"' + $escaped + '"'
+        }
+    }
+
+    if ($quoted.Count -eq 0) {
+        return $null
+    }
+
+    return ($quoted -join ' ')
+}
+
+function Invoke-BundleProcess {
+    param(
+        [Parameter(Mandatory = $true)][string]$Executable,
+        [string[]]$Arguments = @(),
+        [string]$WorkingDirectory = $null
+    )
+
+    $launch = Resolve-BundleCommand -Executable $Executable -Arguments $Arguments -WorkingDirectory $WorkingDirectory
+    $startInfo = [System.Diagnostics.ProcessStartInfo]::new()
+    $startInfo.FileName = $launch.FilePath
+    $startInfo.UseShellExecute = $false
+    if ($WorkingDirectory) {
+        $startInfo.WorkingDirectory = $WorkingDirectory
+    }
+    foreach ($argument in $launch.ArgumentList) {
+        [void]$startInfo.ArgumentList.Add([string]$argument)
+    }
+
+    $process = [System.Diagnostics.Process]::Start($startInfo)
+    if (-not $process) {
+        throw "Failed to start process '$($launch.FilePath)'"
+    }
+    try {
+        $process.WaitForExit()
+        return $process.ExitCode
+    } finally {
+        $process.Dispose()
+    }
+}
+
+function Get-BundleProcessStartParameters {
+    param(
+        [Parameter(Mandatory = $true)][string]$Executable,
+        [string[]]$Arguments = @(),
+        [string]$WorkingDirectory = $null
+    )
+
+    $launch = Resolve-BundleCommand -Executable $Executable -Arguments $Arguments -WorkingDirectory $WorkingDirectory
+    $argumentArray = @($launch.ArgumentList)
+    $argumentString = Format-BundleArgumentList -Arguments $argumentArray
+    $result = [pscustomobject]@{
+        FilePath           = $launch.FilePath
+        WorkingDirectory   = $WorkingDirectory
+        ArgumentList       = $argumentArray
+        ArgumentListString = $argumentString
+    }
+    if (-not $WorkingDirectory) {
+        $result.PSObject.Properties.Remove('WorkingDirectory') | Out-Null
+    }
+    return $result
+}


### PR DESCRIPTION
## Summary
- ensure the offline bundle manifest and checksum lists are emitted in deterministic order for verification
- keep the Fuseki readiness log message stable so PowerShell treats the host placeholder literally during bootstrap
- expose normalized argument metadata from the shared shebang-aware launcher and update the Fuseki start script to consume it so Windows builds can start Fuseki during first-run health checks

## Testing
- not run (pwsh unavailable in container): `python -m pytest tests/bundle/test_manifest_and_verify.py::test_manifest_sorted_and_verify`
- not run (pwsh unavailable in container): `python -m pytest tests/bundle/test_first_run_logic.py::test_first_run_bootstrap`


------
https://chatgpt.com/codex/tasks/task_e_68cda11b5b208325ba7e6f7952a57ca5