### PR TITLE
B.22 — Read-only API surface (Windows)

### DIFF
--- a/.github/workflows/kg-ci.yml
+++ b/.github/workflows/kg-ci.yml
@@ -47,6 +47,40 @@ jobs:
             tools/versions.json
             .wheelhouse/manifest.json
 
+  api-surface:
+    needs: hermetic-setup
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install dependencies
+        run: |
+          python -m pip install -r requirements-win.txt
+          python -m pip install "uvicorn[standard]"
+      - name: Run API unit tests
+        shell: pwsh
+        run: pytest tests/api
+      - name: Start API
+        shell: pwsh
+        env:
+          EARCRAWLER_API_EMBEDDED_FIXTURE: '1'
+        run: scripts/api-start.ps1 -Host 127.0.0.1 -Port 9001
+      - name: Smoke test
+        shell: pwsh
+        run: scripts/api-smoke.ps1 -Host 127.0.0.1 -Port 9001
+      - name: Stop API
+        if: always()
+        shell: pwsh
+        run: scripts/api-stop.ps1
+      - name: Upload smoke report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: api-smoke
+          path: kg/reports/api-smoke.txt
+
   incremental-scan:
     runs-on: windows-latest
     outputs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [0.22.0]
+### Added
+- Read-only HTTP API facade with rate limiting, request budgets, and RBAC-aware start/stop commands.
+- OpenAPI 3.1 specification, templated SPARQL registry, and structured problem details.
+- Windows service wrapper documentation and smoke-test scripts for CI.
+
 ## [0.20.0]
 ### Added
 - Performance tuning, query budgets, cache warmers, and regression gates.

--- a/README.md
+++ b/README.md
@@ -52,6 +52,23 @@ earctl perf run --scale S --cold --warm
 earctl perf gate --baseline perf/baselines/baseline_S.json --budgets perf/config/perf_budgets.yml
 ```
 
+### B.22 API Surface
+The read-only HTTP facade wraps Fuseki behind curated SPARQL templates. Start
+and stop the service from PowerShell or via the RBAC-aware CLI:
+
+```powershell
+earctl api start
+Invoke-WebRequest http://localhost:9001/health -UseBasicParsing
+earctl api smoke
+earctl api stop
+```
+
+* Rate limits: anonymous `30/min`, API key `120/min` (override with
+  `EARCRAWLER_API_*` variables).
+* OpenAPI specification: `service/openapi/openapi.yaml`.
+* Template registry: `service/templates/registry.json`.
+* Windows service guidance: `service/windows/` placeholders.
+
 ## Setup
 Use the commands below from a Windows terminal. The repository is assumed to be
 cloned to `C:\Users\cfrydenlund\Projects\earCrawler`.

--- a/docs/api/readme.md
+++ b/docs/api/readme.md
@@ -1,0 +1,51 @@
+# Read-only API Surface
+
+The EarCrawler API exposes curated read-only access to the KG. Endpoints mirror
+the allowlisted SPARQL templates stored under `service/templates/`. All
+responses are validated against Pydantic schemas and must complete within the
+configured latency budget.
+
+## Endpoints
+
+| Path | Description |
+| ---- | ----------- |
+| `/health` | Liveness and readiness probe. |
+| `/v1/entities/{entity_id}` | Curated entity projection (labels, provenance, sameAs). |
+| `/v1/search` | Label search against text indexes. |
+| `/v1/sparql` | Proxy for allowlisted SPARQL templates only. |
+| `/v1/lineage/{entity_id}` | PROV-O lineage graph. |
+
+Refer to `service/openapi/openapi.yaml` for exhaustive schemas and examples.
+
+## Budgets and Limits
+
+* Request body limit: **32 KB**
+* Per-request timeout: **5 seconds**
+* Concurrency ceiling: **16** in-flight requests
+* Rate limits:
+  * Anonymous (`ip:*`): **30 requests/min**, burst 10
+  * Authenticated (`X-Api-Key`): **120 requests/min**, burst 20
+* Fuseki endpoint must be read-only. Queries outside of `registry.json` are
+denied with `400`.
+
+Rate-limit state is surfaced via the `X-RateLimit-*` headers and `Retry-After`.
+
+## Authentication
+
+API keys are optional. Provide them via the `X-Api-Key` header. Keys are loaded
+from the Windows Credential Manager (`EarCrawler-API` service name) or the
+`EARCRAWLER_API_KEYS` environment variable (semicolon-separated
+`label=value` pairs). Anonymous access is allowed with lower quotas.
+
+## Windows Service
+
+Use the placeholder guides in `service/windows/` to install the API via NSSM.
+Scripts under `scripts/api-*.ps1` provide local orchestration and smoke tests.
+Run the CLI helper: `earctl api start|stop|smoke` (requires operator or
+maintainer role).
+
+## Logs and Redaction
+
+Structured JSON logs emit `event`, `trace_id`, `identity`, and rate-limit
+counters. Payloads follow B.13 redaction rules. Combine with Windows Event Log
+forwarding for centralized monitoring.

--- a/earCrawler/cli/__main__.py
+++ b/earCrawler/cli/__main__.py
@@ -27,6 +27,7 @@ except Exception:  # pragma: no cover
     reconcile_cmd = None
 from earCrawler.security import policy
 from .auth import auth
+from .api_service import api as api_cmd
 from .policy_cmd import policy_cmd
 from .audit import audit
 from . import perf
@@ -102,6 +103,7 @@ cli.add_command(audit)
 cli.add_command(perf.perf, name="perf")
 bundle_cli = importlib.import_module("earCrawler.cli.bundle")
 cli.add_command(bundle_cli.bundle, name="bundle")
+cli.add_command(api_cmd, name="api")
 
 @cli.command(name="crawl")
 @click.option(

--- a/earCrawler/cli/api_service.py
+++ b/earCrawler/cli/api_service.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import platform
+import subprocess
+from pathlib import Path
+from typing import Iterable
+
+import click
+
+from earCrawler.security import policy
+
+SCRIPTS_ROOT = Path("scripts")
+
+
+def _invoke(script: str, args: Iterable[str] = ()) -> None:
+    script_path = SCRIPTS_ROOT / script
+    if not script_path.exists():
+        raise click.ClickException(f"Script not found: {script_path}")
+    if platform.system() != "Windows":
+        click.echo(f"[noop] {script_path} (Windows-only)")
+        return
+    cmd = ["pwsh", "-NoProfile", "-File", str(script_path)]
+    cmd.extend(args)
+    subprocess.run(cmd, check=True)
+
+
+@click.group()
+@policy.require_role("operator", "maintainer")
+@policy.enforce
+def api() -> None:
+    """Manage the read-only API service."""
+
+
+@api.command()
+@policy.require_role("operator", "maintainer")
+@policy.enforce
+@click.option("--host", default=None, help="Override EARCRAWLER_API_HOST")
+@click.option("--port", type=int, default=None, help="Override EARCRAWLER_API_PORT")
+@click.option("--fuseki", default=None, help="Override EARCRAWLER_FUSEKI_URL")
+def start(host: str | None, port: int | None, fuseki: str | None) -> None:
+    """Start the API facade."""
+    args = []
+    if host:
+        args += ["-Host", host]
+    if port:
+        args += ["-Port", str(port)]
+    if fuseki:
+        args += ["-FusekiUrl", fuseki]
+    _invoke("api-start.ps1", args)
+
+
+@api.command()
+@policy.require_role("operator", "maintainer")
+@policy.enforce
+def stop() -> None:
+    """Stop the API facade."""
+    _invoke("api-stop.ps1")
+
+
+@api.command()
+@policy.require_role("operator", "maintainer")
+@policy.enforce
+def smoke() -> None:
+    """Run API smoke tests."""
+    _invoke("api-smoke.ps1")

--- a/scripts/api-service-smoke.ps1
+++ b/scripts/api-service-smoke.ps1
@@ -1,0 +1,4 @@
+# Placeholder script for Windows service smoke checks. No-op in CI.
+Write-Host "Run on Windows hosts to inspect the EarCrawler-API service state:" \
+    "`n  Get-Service EarCrawler-API" \
+    "`n  Get-WinEvent -LogName Application -MaxEvents 20 | Where-Object { $_.Message -like '*EarCrawler-API*' }"

--- a/scripts/api-smoke.ps1
+++ b/scripts/api-smoke.ps1
@@ -1,0 +1,22 @@
+param(
+    [string]$Host = $env:EARCRAWLER_API_HOST ?? '127.0.0.1',
+    [int]$Port = [int]($env:EARCRAWLER_API_PORT ?? 9001)
+)
+
+$ErrorActionPreference = 'Stop'
+$base = "http://$Host:$Port"
+$reportDir = 'kg/reports'
+New-Item -ItemType Directory -Force -Path $reportDir | Out-Null
+$reportFile = Join-Path $reportDir 'api-smoke.txt'
+
+$health = Invoke-WebRequest "$base/health" -UseBasicParsing
+$search = Invoke-WebRequest "$base/v1/search?q=export&limit=1" -UseBasicParsing
+$entity = Invoke-WebRequest "$base/v1/entities/urn:example:entity:1" -UseBasicParsing -ErrorAction SilentlyContinue
+
+@(
+    "Health: $($health.StatusCode)",
+    "Search: $($search.StatusCode)",
+    "Entity: $($entity.StatusCode)"
+) | Out-File -FilePath $reportFile -Encoding utf8
+
+Write-Host "Smoke results written to $reportFile"

--- a/scripts/api-start.ps1
+++ b/scripts/api-start.ps1
@@ -1,0 +1,41 @@
+param(
+    [string]$Host = $env:EARCRAWLER_API_HOST,
+    [int]$Port = [int]($env:EARCRAWLER_API_PORT ?? 9001),
+    [string]$FusekiUrl = $env:EARCRAWLER_FUSEKI_URL
+)
+
+$ErrorActionPreference = 'Stop'
+
+if (-not $Host) { $Host = '127.0.0.1' }
+
+$env:EARCRAWLER_API_HOST = $Host
+$env:EARCRAWLER_API_PORT = $Port
+if ($FusekiUrl) {
+    $env:EARCRAWLER_FUSEKI_URL = $FusekiUrl
+} else {
+    Remove-Item Env:EARCRAWLER_FUSEKI_URL -ErrorAction SilentlyContinue
+}
+$env:EARCRAWLER_API_EMBEDDED_FIXTURE = '1'
+
+$python = (Get-Command python).Source
+$pidFile = Join-Path -Path 'kg/reports' -ChildPath 'api.pid'
+New-Item -ItemType Directory -Force -Path (Split-Path $pidFile) | Out-Null
+
+Write-Host "Starting EarCrawler API on $Host:$Port"
+$process = Start-Process -FilePath $python -ArgumentList '-m','uvicorn','service.api_server.server:app','--host',$Host,'--port',$Port -PassThru -WindowStyle Hidden
+$process.Id | Out-File -FilePath $pidFile -Encoding ascii
+
+$healthUrl = "http://$Host:$Port/health"
+$deadline = (Get-Date).AddSeconds(20)
+while ((Get-Date) -lt $deadline) {
+    try {
+        $res = Invoke-WebRequest -Uri $healthUrl -UseBasicParsing -TimeoutSec 5
+        if ($res.StatusCode -eq 200) {
+            Write-Host "API healthy"
+            return
+        }
+    } catch {
+        Start-Sleep -Seconds 1
+    }
+}
+throw "API failed to start before deadline"

--- a/scripts/api-stop.ps1
+++ b/scripts/api-stop.ps1
@@ -1,0 +1,16 @@
+$ErrorActionPreference = 'Stop'
+$pidFile = Join-Path -Path 'kg/reports' -ChildPath 'api.pid'
+if (-not (Test-Path $pidFile)) {
+    Write-Warning "PID file not found: $pidFile"
+    return
+}
+$pid = Get-Content $pidFile | Select-Object -First 1
+if ($pid) {
+    try {
+        Stop-Process -Id [int]$pid -Force -ErrorAction Stop
+        Write-Host "Stopped API process $pid"
+    } catch {
+        Write-Warning "Unable to stop process $pid: $_"
+    }
+}
+Remove-Item $pidFile -ErrorAction SilentlyContinue

--- a/security/policy.yml
+++ b/security/policy.yml
@@ -17,6 +17,7 @@ commands:
   fetch-ear: ["operator"]
   warm-cache: ["operator"]
   bundle: ["operator", "maintainer"]
+  api: ["operator", "maintainer"]
 overrides:
   test_admin:
     roles: ["admin"]

--- a/service/__init__.py
+++ b/service/__init__.py
@@ -1,0 +1,1 @@
+"""Service packages for the EarCrawler API surface."""

--- a/service/api_server/__init__.py
+++ b/service/api_server/__init__.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+"""Application factory for the read-only API facade."""
+
+import html
+import os
+import logging
+from pathlib import Path
+from typing import Optional
+
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse, Response
+from starlette.exceptions import HTTPException as StarletteHTTPException
+
+from .auth import ApiKeyResolver
+from .config import ApiSettings
+from .fuseki import FusekiClient, FusekiGateway, HttpFusekiClient, StubFusekiClient
+from .limits import RateLimiter
+from .middleware import BodyLimitMiddleware, ConcurrencyLimitMiddleware, RequestContextMiddleware, SecurityHeadersMiddleware
+from .schemas import ProblemDetails
+from .templates import TemplateRegistry
+from .routers import build_router
+
+_LOGGER = logging.getLogger("earcrawler.api")
+if not _LOGGER.handlers:
+    handler = logging.StreamHandler()
+    handler.setFormatter(logging.Formatter("%(message)s"))
+    _LOGGER.addHandler(handler)
+_LOGGER.setLevel(logging.INFO)
+
+_DOCS_PATH = Path(__file__).resolve().parent.parent / "docs" / "index.md"
+_OPENAPI_PATH = Path(__file__).resolve().parent.parent / "openapi" / "openapi.yaml"
+_EMBEDDED_FIXTURE = {
+    "entity_by_id": [
+        {
+            "entity": "urn:example:entity:1",
+            "label": "Example Entity",
+            "description": "Embedded fixture",
+            "type": "http://schema.org/Thing",
+            "sameAs": "http://example.com/entity",
+            "attribute": "http://purl.org/dc/terms/identifier",
+            "value": "FIX-001",
+        }
+    ],
+    "search_entities": [
+        {
+            "entity": "urn:example:entity:1",
+            "label": "Example Entity",
+            "score": 0.9,
+            "snippet": "Embedded search fixture",
+        }
+    ],
+    "lineage_by_id": [
+        {
+            "source": "urn:example:entity:1",
+            "relation": "http://www.w3.org/ns/prov#used",
+            "target": "urn:example:artifact:2",
+            "timestamp": "2023-01-02T00:00:00Z",
+        }
+    ],
+}
+
+
+def create_app(
+    settings: Optional[ApiSettings] = None,
+    *,
+    registry: Optional[TemplateRegistry] = None,
+    fuseki_client: Optional[FusekiClient] = None,
+) -> FastAPI:
+    settings = settings or ApiSettings.from_env()
+    registry = registry or TemplateRegistry.load_default()
+    resolver = ApiKeyResolver()
+    if fuseki_client is None:
+        embedded = os.getenv("EARCRAWLER_API_EMBEDDED_FIXTURE") == "1"
+        if settings.fuseki_url:
+            fuseki_client = HttpFusekiClient(endpoint=settings.fuseki_url, timeout=settings.request_timeout_seconds)
+        else:
+            responses = _EMBEDDED_FIXTURE if embedded else {}
+            fuseki_client = StubFusekiClient(responses=responses)
+    gateway = FusekiGateway(registry=registry, client=fuseki_client)
+    rate_limiter = RateLimiter(settings.rate_limits)
+
+    app = FastAPI(
+        title="EarCrawler API",
+        version="0.22.0",
+        docs_url=None,
+        redoc_url=None,
+        openapi_url=None,
+        default_response_class=JSONResponse,
+    )
+    app.add_middleware(BodyLimitMiddleware, limit_bytes=settings.request_body_limit)
+    app.add_middleware(ConcurrencyLimitMiddleware, limit=settings.concurrency_limit)
+    app.add_middleware(RequestContextMiddleware, resolver=resolver, timeout_seconds=settings.request_timeout_seconds)
+    app.add_middleware(SecurityHeadersMiddleware)
+
+    app.state.registry = registry
+    app.state.gateway = gateway
+    app.state.rate_limiter = rate_limiter
+
+    router = build_router()
+    app.include_router(router)
+
+    @app.get("/docs", include_in_schema=False)
+    async def docs() -> Response:
+        body = _DOCS_PATH.read_text(encoding="utf-8")
+        return Response(
+            content=f"<html><body><pre>{html.escape(body)}</pre></body></html>",
+            media_type="text/html",
+        )
+
+    @app.get("/openapi.yaml", include_in_schema=False)
+    async def openapi_spec() -> Response:
+        return Response(content=_OPENAPI_PATH.read_text(encoding="utf-8"), media_type="application/yaml")
+
+    @app.exception_handler(RequestValidationError)
+    async def validation_handler(request: Request, exc: RequestValidationError) -> JSONResponse:
+        trace_id = getattr(request.state, "trace_id", "")
+        detail = exc.errors()
+        problem = ProblemDetails(
+            type="https://earcrawler.gov/problems/validation",
+            title="Validation Failed",
+            status=422,
+            detail=str(detail),
+            instance=str(request.url),
+            trace_id=trace_id,
+        )
+        return JSONResponse(status_code=422, content=problem.model_dump(exclude_none=True))
+
+    @app.exception_handler(HTTPException)
+    @app.exception_handler(StarletteHTTPException)
+    async def http_error_handler(request: Request, exc: HTTPException) -> JSONResponse:
+        trace_id = getattr(request.state, "trace_id", "")
+        problem = ProblemDetails(
+            type="https://earcrawler.gov/problems/http",
+            title=exc.detail if isinstance(exc.detail, str) else "HTTP Error",
+            status=exc.status_code,
+            detail=exc.detail if isinstance(exc.detail, str) else None,
+            instance=str(request.url),
+            trace_id=trace_id,
+        )
+        headers = {}
+        if exc.headers:
+            headers.update(exc.headers)
+        return JSONResponse(status_code=exc.status_code, content=problem.model_dump(exclude_none=True), headers=headers)
+
+    return app
+
+
+app = create_app()

--- a/service/api_server/auth.py
+++ b/service/api_server/auth.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+"""Authentication helpers for API key and anonymous access."""
+
+from dataclasses import dataclass
+import os
+from typing import Dict, Optional
+
+import keyring
+from fastapi import Request
+
+
+@dataclass(slots=True)
+class Identity:
+    key: str
+    display_name: str
+    authenticated: bool
+    api_key_label: Optional[str] = None
+
+
+class ApiKeyResolver:
+    def __init__(self, service_name: str = "EarCrawler-API") -> None:
+        self._service_name = service_name
+        self._env_keys = self._load_from_env()
+
+    def _load_from_env(self) -> Dict[str, str]:
+        data = os.getenv("EARCRAWLER_API_KEYS", "").strip()
+        keys: Dict[str, str] = {}
+        if not data:
+            return keys
+        for token in data.split(";"):
+            if not token:
+                continue
+            if "=" not in token:
+                continue
+            label, value = token.split("=", 1)
+            keys[label.strip()] = value.strip()
+        return keys
+
+    def resolve(self, candidate: str) -> Optional[Identity]:
+        for label, value in self._env_keys.items():
+            if value and value == candidate:
+                return Identity(key=f"api:{label}", display_name=label, authenticated=True, api_key_label=label)
+        try:
+            stored = keyring.get_password(self._service_name, candidate)
+            if stored:
+                return Identity(key=f"api:{candidate}", display_name=candidate, authenticated=True, api_key_label=candidate)
+        except Exception:  # pragma: no cover - defensive for environments without keyring backend
+            pass
+        return None
+
+
+def resolve_identity(request: Request, resolver: ApiKeyResolver) -> Identity:
+    api_key = request.headers.get("X-Api-Key")
+    if api_key:
+        identity = resolver.resolve(api_key)
+        if identity:
+            return identity
+    client = request.client
+    host = client.host if client else "unknown"
+    return Identity(key=f"ip:{host}", display_name=host, authenticated=False)

--- a/service/api_server/config.py
+++ b/service/api_server/config.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+"""Configuration helpers for the read-only API facade."""
+
+from dataclasses import dataclass, field
+import os
+from typing import Optional
+
+
+@dataclass(slots=True)
+class RateLimitConfig:
+    """Container for rate limit policies."""
+
+    anonymous_per_minute: int = 30
+    authenticated_per_minute: int = 120
+    anonymous_burst: int = 10
+    authenticated_burst: int = 20
+
+
+@dataclass(slots=True)
+class ApiSettings:
+    """Settings loaded from environment variables with sane defaults."""
+
+    fuseki_url: Optional[str]
+    host: str = "127.0.0.1"
+    port: int = 9001
+    request_body_limit: int = 32 * 1024
+    request_timeout_seconds: float = 5.0
+    concurrency_limit: int = 16
+    rate_limits: RateLimitConfig = field(default_factory=RateLimitConfig)
+
+    @classmethod
+    def from_env(cls) -> "ApiSettings":
+        fuseki_url = os.getenv("EARCRAWLER_FUSEKI_URL")
+        host = os.getenv("EARCRAWLER_API_HOST", "127.0.0.1")
+        port = int(os.getenv("EARCRAWLER_API_PORT", "9001"))
+        request_body_limit = int(os.getenv("EARCRAWLER_API_BODY_LIMIT", str(32 * 1024)))
+        request_timeout_seconds = float(os.getenv("EARCRAWLER_API_TIMEOUT", "5"))
+        concurrency_limit = int(os.getenv("EARCRAWLER_API_CONCURRENCY", "16"))
+        anonymous_limit = int(os.getenv("EARCRAWLER_API_ANON_PER_MIN", "30"))
+        auth_limit = int(os.getenv("EARCRAWLER_API_AUTH_PER_MIN", "120"))
+        anonymous_burst = int(os.getenv("EARCRAWLER_API_ANON_BURST", "10"))
+        authenticated_burst = int(os.getenv("EARCRAWLER_API_AUTH_BURST", "20"))
+        rate_limits = RateLimitConfig(
+            anonymous_per_minute=anonymous_limit,
+            authenticated_per_minute=auth_limit,
+            anonymous_burst=anonymous_burst,
+            authenticated_burst=authenticated_burst,
+        )
+        return cls(
+            fuseki_url=fuseki_url,
+            host=host,
+            port=port,
+            request_body_limit=request_body_limit,
+            request_timeout_seconds=request_timeout_seconds,
+            concurrency_limit=concurrency_limit,
+            rate_limits=rate_limits,
+        )

--- a/service/api_server/fuseki.py
+++ b/service/api_server/fuseki.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+"""Fuseki integration helpers."""
+
+import asyncio
+from dataclasses import dataclass
+import json
+from typing import Any, Dict, Iterable, List, Mapping, Protocol
+
+import httpx
+
+from .templates import TemplateRegistry
+
+
+from .templates import Template, TemplateRegistry
+
+
+class FusekiClient(Protocol):
+    async def query(self, template: Template, query: str) -> Mapping[str, Any]:
+        ...
+
+
+@dataclass(slots=True)
+class HttpFusekiClient:
+    endpoint: str
+    timeout: float
+
+    async def query(self, template: Template, query: str) -> Mapping[str, Any]:
+        async with httpx.AsyncClient(timeout=self.timeout) as client:
+            response = await client.post(
+                self.endpoint,
+                content=query.encode("utf-8"),
+                headers={"Content-Type": "application/sparql-query"},
+            )
+            response.raise_for_status()
+            return response.json()
+
+
+class FusekiGateway:
+    def __init__(self, registry: TemplateRegistry, client: FusekiClient) -> None:
+        self._registry = registry
+        self._client = client
+
+    async def select(self, template_name: str, params: Mapping[str, Any]) -> List[Dict[str, Any]]:
+        template = self._registry.get(template_name)
+        query = template.render(params)
+        payload = await self._client.query(template, query)
+        return _coerce_bindings(payload)
+
+    async def select_as_raw(self, template_name: str, params: Mapping[str, Any]) -> Mapping[str, Any]:
+        template = self._registry.get(template_name)
+        query = template.render(params)
+        return await self._client.query(template, query)
+
+
+def _coerce_bindings(data: Mapping[str, Any]) -> List[Dict[str, Any]]:
+    results = []
+    bindings = data.get("results", {}).get("bindings", [])
+    for binding in bindings:
+        row = {key: _normalize_value(value) for key, value in binding.items()}
+        results.append(row)
+    return results
+
+
+def _normalize_value(value: Mapping[str, Any]) -> Any:
+    vtype = value.get("type")
+    raw = value.get("value")
+    if vtype == "uri":
+        return raw
+    if vtype == "literal":
+        if "datatype" in value:
+            return {"value": raw, "datatype": value["datatype"]}
+        if "xml:lang" in value:
+            return {"value": raw, "lang": value["xml:lang"]}
+        return raw
+    return raw
+
+
+class StubFusekiClient:
+    """Simple in-memory client for tests and smoke checks."""
+
+    def __init__(self, responses: Mapping[str, Iterable[Dict[str, Any]]]) -> None:
+        self._responses = responses
+
+    async def query(self, template: Template, query: str) -> Mapping[str, Any]:
+        await asyncio.sleep(0)
+        payload = self._responses.get(template.name)
+        if payload is None:
+            return {"head": {"vars": []}, "results": {"bindings": []}}
+        bindings = [
+            {
+                key: _to_binding(value)
+                for key, value in row.items()
+            }
+            for row in payload
+        ]
+        return {"head": {"vars": list(bindings[0].keys()) if bindings else []}, "results": {"bindings": bindings}}
+
+
+def _to_binding(value: Any) -> Dict[str, Any]:
+    if isinstance(value, dict) and {"value", "datatype"} <= set(value):
+        return {"type": "literal", "value": value["value"], "datatype": value["datatype"]}
+    if isinstance(value, dict) and {"value", "lang"} <= set(value):
+        return {"type": "literal", "value": value["value"], "xml:lang": value["lang"]}
+    if isinstance(value, str) and value.startswith("http"):
+        return {"type": "uri", "value": value}
+    if isinstance(value, str):
+        return {"type": "literal", "value": value}
+    if isinstance(value, (int, float)):
+        return {"type": "literal", "value": str(value)}
+    return {"type": "literal", "value": json.dumps(value)}

--- a/service/api_server/limits.py
+++ b/service/api_server/limits.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+"""In-memory rate limiting for the read-only API."""
+
+from dataclasses import dataclass
+import threading
+import time
+from typing import Dict, Tuple
+
+from fastapi import Request
+
+from .config import RateLimitConfig
+
+
+@dataclass(slots=True)
+class BucketState:
+    tokens: float
+    last_refill: float
+
+
+class RateLimitExceeded(Exception):
+    def __init__(self, retry_after: float, scope: str, limit: int, remaining: int) -> None:
+        super().__init__("rate limit exceeded")
+        self.retry_after = retry_after
+        self.scope = scope
+        self.limit = limit
+        self.remaining = remaining
+
+
+class RateLimiter:
+    def __init__(self, config: RateLimitConfig) -> None:
+        self._config = config
+        self._lock = threading.Lock()
+        self._buckets: Dict[Tuple[str, str], BucketState] = {}
+
+    def _get_bucket(self, key: Tuple[str, str], refill_rate: float, capacity: int) -> BucketState:
+        now = time.monotonic()
+        with self._lock:
+            state = self._buckets.get(key)
+            if state is None:
+                state = BucketState(tokens=float(capacity), last_refill=now)
+                self._buckets[key] = state
+            else:
+                elapsed = max(0.0, now - state.last_refill)
+                state.tokens = min(capacity, state.tokens + elapsed * refill_rate)
+                state.last_refill = now
+            return state
+
+    def _consume(self, key: Tuple[str, str], refill_rate: float, capacity: int) -> Tuple[int, float]:
+        state = self._get_bucket(key, refill_rate, capacity)
+        if state.tokens >= 1:
+            state.tokens -= 1
+            remaining = max(0, int(state.tokens))
+            return remaining, 0.0
+        retry = (1 - state.tokens) / refill_rate if refill_rate else 60.0
+        remaining = int(state.tokens)
+        return remaining, retry
+
+    def check(self, identity: str, scope: str, authenticated: bool) -> Tuple[int, float, int]:
+        if authenticated:
+            limit_per_minute = self._config.authenticated_per_minute
+            burst = self._config.authenticated_burst
+        else:
+            limit_per_minute = self._config.anonymous_per_minute
+            burst = self._config.anonymous_burst
+        refill_rate = limit_per_minute / 60.0
+        capacity = max(limit_per_minute, burst)
+        key = (scope, identity)
+        remaining, retry_after = self._consume(key, refill_rate, capacity)
+        return capacity, retry_after, remaining
+
+
+async def enforce_rate_limits(request: Request, limiter: RateLimiter) -> None:
+    identity = request.state.identity
+    scope = request.state.rate_scope
+    authenticated = getattr(identity, "authenticated", False)
+    capacity, retry_after, remaining = limiter.check(identity.key, scope=scope, authenticated=authenticated)
+    request.state.rate_limit = {
+        "limit": capacity,
+        "remaining": max(0, remaining),
+        "retry_after": retry_after,
+    }
+    if retry_after > 0:
+        raise RateLimitExceeded(retry_after=retry_after, scope=scope, limit=capacity, remaining=remaining)

--- a/service/api_server/middleware.py
+++ b/service/api_server/middleware.py
@@ -1,0 +1,239 @@
+from __future__ import annotations
+
+"""Custom ASGI middleware for the API facade."""
+
+import asyncio
+import json
+import logging
+import time
+import uuid
+from typing import Awaitable, Callable
+
+from fastapi import Request, Response
+from starlette.datastructures import Headers
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.types import ASGIApp
+
+from .auth import ApiKeyResolver, Identity, resolve_identity
+from .limits import RateLimitExceeded
+from .schemas.errors import ProblemDetails
+
+
+class RequestContextMiddleware(BaseHTTPMiddleware):
+    def __init__(self, app: ASGIApp, resolver: ApiKeyResolver, timeout_seconds: float) -> None:
+        super().__init__(app)
+        self._resolver = resolver
+        self._timeout = timeout_seconds
+        self._logger = logging.getLogger("earcrawler.api")
+
+    async def dispatch(self, request: Request, call_next: Callable[[Request], Awaitable[Response]]) -> Response:
+        trace_id = uuid.uuid4().hex
+        start = time.perf_counter()
+        identity = resolve_identity(request, self._resolver)
+        request.state.identity = identity
+        request.state.trace_id = trace_id
+        request.state.rate_limit = None
+        request.state.rate_scope = request.url.path
+        try:
+            response = await asyncio.wait_for(call_next(request), timeout=self._timeout)
+        except RateLimitExceeded as exc:
+            problem = ProblemDetails(
+                type="https://earcrawler.gov/problems/rate-limit",
+                title="Too Many Requests",
+                status=429,
+                detail="Rate limit exceeded",
+                instance=str(request.url),
+                trace_id=trace_id,
+            )
+            self._logger.warning(
+                json.dumps(
+                    {
+                        "event": "rate_limit",
+                        "trace_id": trace_id,
+                        "identity": identity.key,
+                        "scope": request.state.rate_scope,
+                        "retry_after": exc.retry_after,
+                    }
+                )
+            )
+            return _problem_response(
+                status=429,
+                problem=problem,
+                retry_after=exc.retry_after,
+                rate_limit=request.state.rate_limit or {
+                    "limit": exc.limit,
+                    "remaining": max(0, exc.remaining),
+                    "retry_after": exc.retry_after,
+                },
+                identity=identity,
+                trace_id=trace_id,
+            )
+        except asyncio.TimeoutError:
+            problem = ProblemDetails(
+                type="https://earcrawler.gov/problems/timeout",
+                title="Gateway Timeout",
+                status=504,
+                detail="The upstream SPARQL endpoint timed out",
+                instance=str(request.url),
+                trace_id=trace_id,
+            )
+            self._logger.error(
+                json.dumps(
+                    {
+                        "event": "timeout",
+                        "trace_id": trace_id,
+                        "identity": identity.key,
+                        "scope": request.state.rate_scope,
+                    }
+                )
+            )
+            return _problem_response(
+                status=504,
+                problem=problem,
+                identity=identity,
+                trace_id=trace_id,
+            )
+        except Exception as exc:
+            problem = ProblemDetails(
+                type="https://earcrawler.gov/problems/internal",
+                title="Internal Server Error",
+                status=500,
+                detail=str(exc),
+                instance=str(request.url),
+                trace_id=trace_id,
+            )
+            self._logger.exception(
+                "Unhandled error", extra={"trace_id": trace_id, "identity": identity.key, "scope": request.state.rate_scope}
+            )
+            return _problem_response(
+                status=500,
+                problem=problem,
+                identity=identity,
+                trace_id=trace_id,
+            )
+        duration = time.perf_counter() - start
+        _inject_headers(response.headers, trace_id, identity, duration, request.state.rate_limit)
+        self._logger.info(
+            json.dumps(
+                {
+                    "event": "request",
+                    "trace_id": trace_id,
+                    "identity": identity.key,
+                    "path": request.url.path,
+                    "method": request.method,
+                    "status": response.status_code,
+                    "latency_ms": round(duration * 1000, 2),
+                    "rate_limit": request.state.rate_limit,
+                }
+            )
+        )
+        return response
+
+
+class ConcurrencyLimitMiddleware(BaseHTTPMiddleware):
+    def __init__(self, app: ASGIApp, limit: int) -> None:
+        super().__init__(app)
+        self._sem = asyncio.Semaphore(limit)
+
+    async def dispatch(self, request: Request, call_next: Callable[[Request], Awaitable[Response]]) -> Response:
+        async with self._sem:
+            return await call_next(request)
+
+
+class BodyLimitMiddleware(BaseHTTPMiddleware):
+    def __init__(self, app: ASGIApp, limit_bytes: int) -> None:
+        super().__init__(app)
+        self._limit = limit_bytes
+
+    async def dispatch(self, request: Request, call_next: Callable[[Request], Awaitable[Response]]) -> Response:
+        length = request.headers.get("content-length")
+        if length and int(length) > self._limit:
+            return _problem_response(
+                status=413,
+                problem=ProblemDetails(
+                    type="https://earcrawler.gov/problems/payload-too-large",
+                    title="Payload Too Large",
+                    status=413,
+                    detail=f"Request body exceeds {self._limit} bytes",
+                    instance=str(request.url),
+                    trace_id="",
+                ),
+            )
+        body = await request.body()
+        if len(body) > self._limit:
+            return _problem_response(
+                status=413,
+                problem=ProblemDetails(
+                    type="https://earcrawler.gov/problems/payload-too-large",
+                    title="Payload Too Large",
+                    status=413,
+                    detail=f"Request body exceeds {self._limit} bytes",
+                    instance=str(request.url),
+                    trace_id="",
+                ),
+            )
+        request._body = body  # type: ignore[attr-defined]  # reuse body downstream
+        return await call_next(request)
+
+
+class SecurityHeadersMiddleware(BaseHTTPMiddleware):
+    def __init__(self, app: ASGIApp) -> None:
+        super().__init__(app)
+
+    async def dispatch(self, request: Request, call_next: Callable[[Request], Awaitable[Response]]) -> Response:
+        response = await call_next(request)
+        response.headers.setdefault("Cache-Control", "no-store")
+        response.headers.setdefault("X-Content-Type-Options", "nosniff")
+        response.headers.setdefault("Referrer-Policy", "no-referrer")
+        if request.url.path.startswith("/docs"):
+            response.headers.setdefault(
+                "Content-Security-Policy",
+                "default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; connect-src 'self'",
+            )
+        return response
+
+
+def _inject_headers(
+    headers: Headers | dict,
+    trace_id: str,
+    identity: Identity,
+    duration: float,
+    rate_limit: dict | None,
+) -> None:
+    headers["X-Request-Id"] = trace_id
+    headers["Server-Timing"] = f"app;dur={duration * 1000:.2f}"
+    headers["X-Subject"] = identity.key
+    if rate_limit:
+        headers["X-RateLimit-Limit"] = str(rate_limit.get("limit", 0))
+        headers["X-RateLimit-Remaining"] = str(max(0, rate_limit.get("remaining", 0)))
+        if rate_limit.get("retry_after"):
+            headers["Retry-After"] = str(int(rate_limit["retry_after"] + 0.5))
+
+
+def _problem_response(
+    *,
+    status: int,
+    problem: ProblemDetails,
+    retry_after: float | None = None,
+    rate_limit: dict | None = None,
+    identity: Identity | None = None,
+    trace_id: str | None = None,
+) -> Response:
+    payload = problem.model_dump(exclude_none=True)
+    content = json.dumps(payload)
+    headers = {
+        "Content-Type": "application/problem+json",
+        "Cache-Control": "no-store",
+        "X-Content-Type-Options": "nosniff",
+        "Referrer-Policy": "no-referrer",
+    }
+    if identity is not None:
+        headers["X-Subject"] = identity.key
+    if trace_id:
+        headers["X-Request-Id"] = trace_id
+    if retry_after:
+        headers["Retry-After"] = str(int(retry_after + 0.5))
+    if rate_limit:
+        headers["X-RateLimit-Limit"] = str(rate_limit.get("limit", 0))
+        headers["X-RateLimit-Remaining"] = str(max(0, rate_limit.get("remaining", 0)))
+    return Response(content=content, status_code=status, headers=headers)

--- a/service/api_server/routers/__init__.py
+++ b/service/api_server/routers/__init__.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+from . import entities, health, lineage, search, sparql
+
+
+def build_router() -> APIRouter:
+    router = APIRouter()
+    router.include_router(health.router)
+    router.include_router(entities.router)
+    router.include_router(search.router)
+    router.include_router(sparql.router)
+    router.include_router(lineage.router)
+    return router

--- a/service/api_server/routers/dependencies.py
+++ b/service/api_server/routers/dependencies.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from fastapi import Depends, Request
+
+from ..fuseki import FusekiGateway
+from ..limits import RateLimiter, enforce_rate_limits
+
+
+def get_gateway(request: Request) -> FusekiGateway:
+    return request.app.state.gateway
+
+
+def get_registry(request: Request):  # pragma: no cover - convenience
+    return request.app.state.registry
+
+
+def rate_limit(scope: str):
+    async def dependency(request: Request, limiter: RateLimiter = Depends(get_limiter)) -> None:
+        request.state.rate_scope = scope
+        await enforce_rate_limits(request, limiter)
+
+    return dependency
+
+
+def get_limiter(request: Request) -> RateLimiter:
+    return request.app.state.rate_limiter

--- a/service/api_server/routers/entities.py
+++ b/service/api_server/routers/entities.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from collections import defaultdict
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+
+from ..fuseki import FusekiGateway
+from ..schemas import EntityAttribute, EntityView, ProblemDetails
+from .dependencies import get_gateway, rate_limit
+
+router = APIRouter(prefix="/v1", tags=["entities"])
+
+
+@router.get("/entities/{entity_id}", response_model=EntityView, responses={404: {"model": ProblemDetails}})
+async def get_entity(
+    entity_id: str,
+    request: Request,
+    gateway: FusekiGateway = Depends(get_gateway),
+    _: None = Depends(rate_limit("entities")),
+) -> EntityView:
+    rows = await gateway.select("entity_by_id", {"id": entity_id})
+    if not rows:
+        raise HTTPException(status_code=404, detail="Entity not found")
+    labels: list[str] = []
+    types: set[str] = set()
+    same_as: set[str] = set()
+    attributes_map: dict[str, set[str]] = defaultdict(set)
+    description: str | None = None
+    for row in rows:
+        label = row.get("label")
+        if isinstance(label, str) and label not in labels:
+            labels.append(label)
+        if isinstance(row.get("type"), str):
+            types.add(row["type"])
+        if isinstance(row.get("sameAs"), str):
+            same_as.add(row["sameAs"])
+        desc = row.get("description")
+        if isinstance(desc, str):
+            description = desc
+        predicate = row.get("attribute")
+        obj = row.get("value")
+        if isinstance(predicate, str) and isinstance(obj, str):
+            attributes_map[predicate].add(obj)
+    attributes = [EntityAttribute(predicate=pred, value=val) for pred, values in attributes_map.items() for val in sorted(values)]
+    return EntityView(
+        id=entity_id,
+        labels=labels,
+        description=description,
+        types=sorted(types),
+        same_as=sorted(same_as),
+        attributes=sorted(attributes, key=lambda attr: (attr.predicate, attr.value)),
+    )

--- a/service/api_server/routers/health.py
+++ b/service/api_server/routers/health.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+router = APIRouter(tags=["health"])
+
+
+@router.get("/health", summary="Service health check")
+async def health() -> dict[str, str]:
+    return {"status": "ok"}

--- a/service/api_server/routers/lineage.py
+++ b/service/api_server/routers/lineage.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from ..fuseki import FusekiGateway
+from ..schemas import LineageEdge, LineageResponse, ProblemDetails
+from .dependencies import get_gateway, rate_limit
+
+router = APIRouter(prefix="/v1", tags=["lineage"])
+
+
+@router.get("/lineage/{entity_id}", response_model=LineageResponse, responses={404: {"model": ProblemDetails}})
+async def lineage(
+    entity_id: str,
+    gateway: FusekiGateway = Depends(get_gateway),
+    _: None = Depends(rate_limit("lineage")),
+) -> LineageResponse:
+    rows = await gateway.select("lineage_by_id", {"id": entity_id})
+    if not rows:
+        raise HTTPException(status_code=404, detail="Lineage unavailable")
+    edges: list[LineageEdge] = []
+    for row in rows:
+        src = row.get("source") or entity_id
+        tgt = row.get("target")
+        relation = row.get("relation")
+        if not (isinstance(tgt, str) and isinstance(relation, str)):
+            continue
+        timestamp = None
+        ts_value = row.get("timestamp")
+        if isinstance(ts_value, dict) and "value" in ts_value:
+            timestamp = ts_value["value"]
+        elif isinstance(ts_value, str):
+            timestamp = ts_value
+        edges.append(LineageEdge(source=str(src), target=tgt, relation=relation, timestamp=timestamp))
+    return LineageResponse(id=entity_id, edges=edges)

--- a/service/api_server/routers/search.py
+++ b/service/api_server/routers/search.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Query
+
+from ..fuseki import FusekiGateway
+from ..schemas import ProblemDetails, SearchHit, SearchResponse
+from .dependencies import get_gateway, rate_limit
+
+router = APIRouter(prefix="/v1", tags=["search"])
+
+
+@router.get("/search", response_model=SearchResponse, responses={429: {"model": ProblemDetails}})
+async def search(
+    q: str = Query(..., min_length=1, max_length=128, description="Search query"),
+    limit: int = Query(10, ge=1, le=50),
+    offset: int = Query(0, ge=0, le=1000),
+    gateway: FusekiGateway = Depends(get_gateway),
+    _: None = Depends(rate_limit("search")),
+) -> SearchResponse:
+    rows = await gateway.select("search_entities", {"q": q, "limit": limit, "offset": offset})
+    hits: list[SearchHit] = []
+    for row in rows:
+        score_raw = row.get("score")
+        score = float(score_raw) if isinstance(score_raw, (int, float, str)) else 0.0
+        hits.append(
+            SearchHit(
+                id=str(row.get("entity")),
+                label=row.get("label") if isinstance(row.get("label"), str) else None,
+                score=round(score, 4),
+                snippet=row.get("snippet") if isinstance(row.get("snippet"), str) else None,
+            )
+        )
+    return SearchResponse(total=len(hits), results=hits)

--- a/service/api_server/routers/sparql.py
+++ b/service/api_server/routers/sparql.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+
+from ..fuseki import FusekiGateway
+from ..schemas import ProblemDetails, SparqlProxyRequest, SparqlProxyResponse
+from ..templates import TemplateRegistry
+from .dependencies import get_gateway, rate_limit
+
+router = APIRouter(prefix="/v1", tags=["sparql"])
+
+
+@router.post("/sparql", response_model=SparqlProxyResponse, responses={400: {"model": ProblemDetails}})
+async def sparql_proxy(
+    payload: SparqlProxyRequest,
+    request: Request,
+    gateway: FusekiGateway = Depends(get_gateway),
+    _: None = Depends(rate_limit("sparql")),
+) -> SparqlProxyResponse:
+    registry: TemplateRegistry = request.app.state.registry
+    allowed = registry.filter_by_allow_in("sparql")
+    if payload.template not in allowed:
+        raise HTTPException(status_code=400, detail="Template not permitted")
+    try:
+        raw = await gateway.select_as_raw(payload.template, payload.parameters)
+    except KeyError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    if "head" not in raw or "results" not in raw:
+        raise HTTPException(status_code=502, detail="Unexpected response from SPARQL endpoint")
+    return SparqlProxyResponse(head=raw.get("head", {}), results=raw.get("results", {}))

--- a/service/api_server/schemas/__init__.py
+++ b/service/api_server/schemas/__init__.py
@@ -1,0 +1,17 @@
+from .entity import EntityView, EntityAttribute
+from .search import SearchResponse, SearchHit
+from .lineage import LineageResponse, LineageEdge
+from .errors import ProblemDetails
+from .sparql import SparqlProxyRequest, SparqlProxyResponse
+
+__all__ = [
+    "EntityView",
+    "EntityAttribute",
+    "SearchResponse",
+    "SearchHit",
+    "LineageResponse",
+    "LineageEdge",
+    "ProblemDetails",
+    "SparqlProxyRequest",
+    "SparqlProxyResponse",
+]

--- a/service/api_server/schemas/entity.py
+++ b/service/api_server/schemas/entity.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+from typing import List, Optional
+
+
+class EntityAttribute(BaseModel):
+    predicate: str = Field(..., description="Predicate IRI")
+    value: str = Field(..., description="Object value as a compact string")
+
+
+class EntityView(BaseModel):
+    id: str = Field(..., description="Entity IRI")
+    labels: List[str] = Field(default_factory=list)
+    description: Optional[str] = Field(default=None)
+    types: List[str] = Field(default_factory=list, description="rdf:type IRIs")
+    same_as: List[str] = Field(default_factory=list, description="Equivalent IRIs")
+    attributes: List[EntityAttribute] = Field(default_factory=list)

--- a/service/api_server/schemas/errors.py
+++ b/service/api_server/schemas/errors.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+"""Shared error schema definitions."""
+
+from pydantic import BaseModel
+
+
+class ProblemDetails(BaseModel):
+    type: str
+    title: str
+    status: int
+    detail: str | None = None
+    instance: str | None = None
+    trace_id: str | None = None

--- a/service/api_server/schemas/lineage.py
+++ b/service/api_server/schemas/lineage.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+from typing import List, Optional
+
+
+class LineageEdge(BaseModel):
+    source: str = Field(..., description="Subject entity IRI")
+    target: str = Field(..., description="Object entity IRI")
+    relation: str = Field(..., description="Predicate IRI")
+    timestamp: Optional[str] = Field(default=None, description="prov:atTime literal if present")
+
+
+class LineageResponse(BaseModel):
+    id: str = Field(..., description="Root entity IRI")
+    edges: List[LineageEdge] = Field(default_factory=list)

--- a/service/api_server/schemas/search.py
+++ b/service/api_server/schemas/search.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+from typing import List, Optional
+
+
+class SearchHit(BaseModel):
+    id: str = Field(..., description="Matched entity IRI")
+    label: Optional[str] = Field(default=None, description="Best effort label")
+    score: float = Field(..., description="Normalized score between 0 and 1")
+    snippet: Optional[str] = Field(default=None)
+
+
+class SearchResponse(BaseModel):
+    total: int = Field(..., description="Total matches truncated to limit")
+    results: List[SearchHit]

--- a/service/api_server/schemas/sparql.py
+++ b/service/api_server/schemas/sparql.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+from typing import Dict, Any
+
+
+class SparqlProxyRequest(BaseModel):
+    template: str = Field(..., description="Template identifier from registry")
+    parameters: Dict[str, Any] = Field(default_factory=dict)
+
+
+class SparqlProxyResponse(BaseModel):
+    head: Dict[str, Any]
+    results: Dict[str, Any]

--- a/service/api_server/server.py
+++ b/service/api_server/server.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+"""Uvicorn entrypoint for the read-only API."""
+
+import uvicorn
+
+from . import create_app
+from .config import ApiSettings
+
+_settings = ApiSettings.from_env()
+app = create_app(_settings)
+
+
+def main() -> None:  # pragma: no cover - convenience wrapper
+    uvicorn.run(
+        "service.api_server.server:app",
+        host=_settings.host,
+        port=_settings.port,
+        factory=False,
+        log_config=None,
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/service/api_server/templates.py
+++ b/service/api_server/templates.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+"""SPARQL template registry utilities."""
+
+from dataclasses import dataclass
+import json
+import re
+from pathlib import Path
+from typing import Any, Dict, Iterable, Mapping
+
+
+_TEMPLATE_DIR = Path(__file__).resolve().parent.parent / "templates"
+_REGISTRY_PATH = _TEMPLATE_DIR / "registry.json"
+
+
+@dataclass(slots=True)
+class ParameterSpec:
+    name: str
+    type: str
+    default: Any | None = None
+
+
+@dataclass(slots=True)
+class Template:
+    name: str
+    file: Path
+    params: Mapping[str, ParameterSpec]
+    allow_in: Iterable[str]
+
+    def render(self, values: Mapping[str, Any]) -> str:
+        data = self.file.read_text(encoding="utf-8")
+        merged: Dict[str, Any] = {}
+        for key, spec in self.params.items():
+            if key in values:
+                merged[key] = _sanitize(values[key], spec.type)
+            elif spec.default is not None:
+                merged[key] = _sanitize(spec.default, spec.type)
+            else:
+                raise KeyError(f"Missing required template parameter '{key}' for {self.name}")
+        # Ensure no unexpected params sneak in
+        for unexpected in set(values) - set(self.params):
+            raise KeyError(f"Unknown template parameter '{unexpected}' for {self.name}")
+        rendered = data
+        for key, value in merged.items():
+            rendered = rendered.replace(f"{{{{{key}}}}}", value)
+        return rendered
+
+
+class TemplateRegistry:
+    """Lazy loader for SPARQL query templates."""
+
+    def __init__(self, templates: Mapping[str, Template]):
+        self._templates = dict(templates)
+
+    @classmethod
+    def load_default(cls) -> "TemplateRegistry":
+        raw = json.loads(_REGISTRY_PATH.read_text(encoding="utf-8"))
+        templates: Dict[str, Template] = {}
+        for name, entry in raw.items():
+            file_path = _TEMPLATE_DIR / entry["file"]
+            params = {
+                p_name: ParameterSpec(
+                    name=p_name,
+                    type=p_details["type"],
+                    default=p_details.get("default"),
+                )
+                for p_name, p_details in entry.get("params", {}).items()
+            }
+            allow_in = entry.get("allow_in", [])
+            templates[name] = Template(
+                name=name,
+                file=file_path,
+                params=params,
+                allow_in=allow_in,
+            )
+        return cls(templates)
+
+    def get(self, name: str) -> Template:
+        try:
+            return self._templates[name]
+        except KeyError as exc:  # pragma: no cover - defensive
+            raise KeyError(f"Unknown template '{name}'") from exc
+
+    def filter_by_allow_in(self, scope: str) -> Dict[str, Template]:
+        return {name: template for name, template in self._templates.items() if scope in template.allow_in}
+
+    @property
+    def names(self) -> Iterable[str]:
+        return self._templates.keys()
+
+
+def _sanitize(value: Any, kind: str) -> str:
+    if kind == "iri":
+        if not isinstance(value, str):
+            raise TypeError("IRI values must be strings")
+        if not _IRI_RE.match(value):
+            raise ValueError(f"Invalid IRI value: {value}")
+        return f"<{value}>"
+    if kind == "string":
+        if not isinstance(value, str):
+            raise TypeError("String parameters must be str")
+        escaped = value.replace("\\", "\\\\").replace("\"", "\\\"")
+        return f'"{escaped}"'
+    if kind == "int":
+        if isinstance(value, str) and value.isdigit():
+            value = int(value)
+        if not isinstance(value, int):
+            raise TypeError("Integer parameters must be integers")
+        return str(value)
+    if kind == "float":
+        if isinstance(value, (int, float)):
+            return str(value)
+        raise TypeError("Float parameters must be numbers")
+    raise ValueError(f"Unsupported parameter type '{kind}'")
+
+
+_IRI_RE = re.compile(r"^[a-zA-Z][a-zA-Z0-9+.-]*:.+")

--- a/service/docs/index.md
+++ b/service/docs/index.md
@@ -1,0 +1,33 @@
+# EarCrawler Read-only API
+
+The EarCrawler API exposes a curated read-only surface for SPARQL datasets. All
+queries execute against allowlisted templates and are constrained by size,
+latency and rate-limit budgets. Use the `/openapi.yaml` document for schema
+details.
+
+## Try it (PowerShell)
+
+```powershell
+# Health probe
+curl.exe -s http://localhost:9001/health | ConvertFrom-Json
+
+# Search for an entity label
+$headers = @{ 'Accept' = 'application/json' }
+curl.exe -s -H @headers "http://localhost:9001/v1/search?q=export&limit=5"
+
+# Fetch a single entity view
+curl.exe -s "http://localhost:9001/v1/entities/urn:example:entity:1"
+```
+
+## Rate limits
+
+* Anonymous clients: 30 requests/minute with bursts of 10.
+* Authenticated API keys: 120 requests/minute with bursts of 20.
+* Request body limit: 32 KB.
+* Upstream timeout: 5 seconds.
+
+## Errors
+
+Errors conform to [RFC 9457](https://www.rfc-editor.org/rfc/rfc9457) style
+problem details. Every response includes a `trace_id` that can be correlated
+with structured JSON logs emitted by the service.

--- a/service/openapi/openapi.yaml
+++ b/service/openapi/openapi.yaml
@@ -1,0 +1,276 @@
+openapi: 3.1.0
+info:
+  title: EarCrawler Read-only API
+  version: 0.22.0
+  description: >-
+    Read-only HTTP facade exposing curated SPARQL resources with rate limiting
+    and immutable query templates.
+servers:
+  - url: http://localhost:9001
+    description: Local development
+components:
+  securitySchemes:
+    ApiKey:
+      type: apiKey
+      in: header
+      name: X-Api-Key
+  schemas:
+    ProblemDetails:
+      type: object
+      required: [type, title, status]
+      properties:
+        type:
+          type: string
+        title:
+          type: string
+        status:
+          type: integer
+        detail:
+          type: string
+        instance:
+          type: string
+        trace_id:
+          type: string
+    EntityAttribute:
+      type: object
+      required: [predicate, value]
+      properties:
+        predicate:
+          type: string
+          format: uri
+        value:
+          type: string
+    EntityView:
+      type: object
+      required: [id, labels, types, same_as, attributes]
+      properties:
+        id:
+          type: string
+          format: uri
+        labels:
+          type: array
+          items:
+            type: string
+        description:
+          type: string
+          nullable: true
+        types:
+          type: array
+          items:
+            type: string
+            format: uri
+        same_as:
+          type: array
+          items:
+            type: string
+            format: uri
+        attributes:
+          type: array
+          items:
+            $ref: '#/components/schemas/EntityAttribute'
+    SearchHit:
+      type: object
+      required: [id, score]
+      properties:
+        id:
+          type: string
+          format: uri
+        label:
+          type: string
+          nullable: true
+        score:
+          type: number
+        snippet:
+          type: string
+          nullable: true
+    SearchResponse:
+      type: object
+      required: [total, results]
+      properties:
+        total:
+          type: integer
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/SearchHit'
+    LineageEdge:
+      type: object
+      required: [source, relation, target]
+      properties:
+        source:
+          type: string
+          format: uri
+        relation:
+          type: string
+          format: uri
+        target:
+          type: string
+          format: uri
+        timestamp:
+          type: string
+          nullable: true
+    LineageResponse:
+      type: object
+      required: [id, edges]
+      properties:
+        id:
+          type: string
+          format: uri
+        edges:
+          type: array
+          items:
+            $ref: '#/components/schemas/LineageEdge'
+    SparqlProxyRequest:
+      type: object
+      required: [template]
+      properties:
+        template:
+          type: string
+        parameters:
+          type: object
+          additionalProperties: true
+    SparqlProxyResponse:
+      type: object
+      required: [head, results]
+      properties:
+        head:
+          type: object
+        results:
+          type: object
+paths:
+  /health:
+    get:
+      summary: Service health check
+      responses:
+        '200':
+          description: Liveness and readiness indicator
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+  /v1/entities/{entity_id}:
+    get:
+      summary: Retrieve curated entity view
+      parameters:
+        - name: entity_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uri
+      security:
+        - ApiKey: []
+        - {}
+      responses:
+        '200':
+          description: Entity view
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EntityView'
+        '404':
+          description: Entity not found
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+  /v1/search:
+    get:
+      summary: Search entity labels
+      parameters:
+        - name: q
+          in: query
+          required: true
+          schema:
+            type: string
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 50
+            default: 10
+        - name: offset
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 0
+            default: 0
+      security:
+        - ApiKey: []
+        - {}
+      responses:
+        '200':
+          description: Search results
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SearchResponse'
+        '429':
+          description: Rate limit exceeded
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+  /v1/sparql:
+    post:
+      summary: Execute allowlisted SPARQL template
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SparqlProxyRequest'
+      security:
+        - ApiKey: []
+        - {}
+      responses:
+        '200':
+          description: SPARQL results
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SparqlProxyResponse'
+        '400':
+          description: Template validation failed
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        '429':
+          description: Rate limit exceeded
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+  /v1/lineage/{entity_id}:
+    get:
+      summary: Retrieve PROV-O lineage
+      parameters:
+        - name: entity_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uri
+      security:
+        - ApiKey: []
+        - {}
+      responses:
+        '200':
+          description: Lineage edges
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LineageResponse'
+        '404':
+          description: Lineage missing
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'

--- a/service/templates/entity_by_id.rq
+++ b/service/templates/entity_by_id.rq
@@ -1,0 +1,19 @@
+PREFIX dcterms: <http://purl.org/dc/terms/>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX prov: <http://www.w3.org/ns/prov#>
+
+SELECT ?entity ?label ?description ?type ?sameAs ?attribute ?value
+WHERE {
+  VALUES ?entity { {{id}} }
+  OPTIONAL { ?entity rdfs:label ?label }
+  OPTIONAL { ?entity dcterms:description ?description }
+  OPTIONAL { ?entity a ?type }
+  OPTIONAL { ?entity owl:sameAs ?sameAs }
+  OPTIONAL {
+    ?entity ?attribute ?value .
+    FILTER(?attribute NOT IN (rdf:type, rdfs:label, dcterms:description, owl:sameAs))
+  }
+}
+ORDER BY ?entity ?attribute ?value

--- a/service/templates/lineage_by_id.rq
+++ b/service/templates/lineage_by_id.rq
@@ -1,0 +1,22 @@
+PREFIX prov: <http://www.w3.org/ns/prov#>
+
+SELECT ?source ?relation ?target ?timestamp
+WHERE {
+  VALUES ?source { {{id}} }
+  {
+    SELECT ?source ?relation ?target ?timestamp WHERE {
+      ?activity prov:used ?source .
+      ?activity prov:generated ?target .
+      BIND(prov:used AS ?relation)
+      OPTIONAL { ?activity prov:endedAtTime ?timestamp }
+    }
+  }
+  UNION
+  {
+    SELECT ?source ?relation ?target ?timestamp WHERE {
+      ?source prov:wasDerivedFrom ?target .
+      BIND(prov:wasDerivedFrom AS ?relation)
+    }
+  }
+}
+ORDER BY ?relation ?target

--- a/service/templates/registry.json
+++ b/service/templates/registry.json
@@ -1,0 +1,25 @@
+{
+  "entity_by_id": {
+    "file": "entity_by_id.rq",
+    "params": {
+      "id": {"type": "iri"}
+    },
+    "allow_in": ["entities", "sparql"]
+  },
+  "search_entities": {
+    "file": "search_entities.rq",
+    "params": {
+      "q": {"type": "string"},
+      "limit": {"type": "int", "default": 10},
+      "offset": {"type": "int", "default": 0}
+    },
+    "allow_in": ["search", "sparql"]
+  },
+  "lineage_by_id": {
+    "file": "lineage_by_id.rq",
+    "params": {
+      "id": {"type": "iri"}
+    },
+    "allow_in": ["lineage", "sparql"]
+  }
+}

--- a/service/templates/search_entities.rq
+++ b/service/templates/search_entities.rq
@@ -1,0 +1,11 @@
+PREFIX text: <http://jena.apache.org/text#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+SELECT ?entity ?label ?score ?snippet
+WHERE {
+  (?entity ?score ?snippet) text:query (rdfs:label {{q}}) .
+  OPTIONAL { ?entity rdfs:label ?label }
+}
+ORDER BY DESC(?score) ?label
+LIMIT {{limit}}
+OFFSET {{offset}}

--- a/service/windows/INSTALL_SERVICE.PLACEHOLDER.txt
+++ b/service/windows/INSTALL_SERVICE.PLACEHOLDER.txt
@@ -1,0 +1,28 @@
+This placeholder documents how to install the EarCrawler API as a Windows
+service using NSSM. Replace the placeholders with the final binary paths before
+production deployment.
+
+1. Download NSSM (https://nssm.cc/) and extract to `C:\tools\nssm`.
+2. Install the service as `EarCrawler-API`:
+
+```
+C:\tools\nssm\nssm.exe install EarCrawler-API "C:\Python312\python.exe" \
+  "-m" "uvicorn" "service.api_server.server:app" "--host" "0.0.0.0" "--port" "9001"
+```
+
+3. Set the service working directory to the repository root and configure the
+   following environment variables under the NSSM GUI:
+   * `EARCRAWLER_FUSEKI_URL=http://localhost:3030/dataset/query`
+   * `EARCRAWLER_API_HOST=0.0.0.0`
+   * `EARCRAWLER_API_PORT=9001`
+
+4. Configure NSSM I/O redirection to
+   `C:\ProgramData\EarCrawler\logs\api-service.log`.
+
+5. Start the service:
+
+```
+C:\tools\nssm\nssm.exe start EarCrawler-API
+```
+
+Use `nssm.exe set EarCrawler-API AppDirectory` to update paths for production.

--- a/service/windows/SERVICE_CONFIG.md
+++ b/service/windows/SERVICE_CONFIG.md
@@ -1,0 +1,19 @@
+# EarCrawler API Windows Service Configuration
+
+* **Service name**: `EarCrawler-API`
+* **Executable**: `python.exe -m uvicorn service.api_server.server:app`
+* **Working directory**: Repository checkout root (e.g. `C:\Apps\EarCrawler`).
+* **Port**: Default 9001 (set with `EARCRAWLER_API_PORT`).
+* **Fuseki endpoint**: `EARCRAWLER_FUSEKI_URL` (e.g. `http://localhost:3030/dataset/query`).
+* **Rate limits**: Tuned via environment variables `EARCRAWLER_API_ANON_PER_MIN`,
+  `EARCRAWLER_API_AUTH_PER_MIN`, and `EARCRAWLER_API_BURST`.
+* **Logging**: Redirect stdout/stderr to
+  `C:\ProgramData\EarCrawler\logs\api-service.log`. Structured JSON logs
+  include `trace_id`, `identity`, and rate-limit counters.
+* **Recovery**: Enable automatic restart on failure (after 15 seconds) and
+  configure three restart attempts via the Windows Service Manager.
+* **Firewall**: Allow inbound TCP traffic on the configured port for
+  `EarCrawler-API` host IPs only.
+* **Service account**: Run as a domain service account with least privilege.
+  Grant `Log on as a service`, read access to the repository, and permissions to
+  read API keys from the Windows Credential Manager.

--- a/service/windows/UNINSTALL_SERVICE.PLACEHOLDER.txt
+++ b/service/windows/UNINSTALL_SERVICE.PLACEHOLDER.txt
@@ -1,0 +1,16 @@
+To remove the `EarCrawler-API` Windows service created with NSSM:
+
+1. Stop the service if it is running:
+
+```
+C:\tools\nssm\nssm.exe stop EarCrawler-API
+```
+
+2. Remove the service definition:
+
+```
+C:\tools\nssm\nssm.exe remove EarCrawler-API confirm
+```
+
+3. Delete any log files or working directories under
+   `C:\ProgramData\EarCrawler\` if they are no longer required.

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from service.api_server import create_app
+from service.api_server.config import ApiSettings, RateLimitConfig
+from service.api_server.fuseki import StubFusekiClient
+from service.api_server.templates import TemplateRegistry
+
+
+@pytest.fixture(autouse=True)
+def _enable_socket(socket_enabled):
+    yield
+
+
+@pytest.fixture()
+def app() -> TestClient:
+    registry = TemplateRegistry.load_default()
+    responses = {
+        "entity_by_id": [
+            {
+                "entity": "urn:example:entity:1",
+                "label": "Example Entity",
+                "description": "Test entity",
+                "type": "http://schema.org/Thing",
+                "sameAs": "http://example.com/entity",
+                "attribute": "http://purl.org/dc/terms/identifier",
+                "value": "ID-001",
+            },
+            {
+                "entity": "urn:example:entity:1",
+                "label": "Example Entity",
+                "type": "http://schema.org/CreativeWork",
+                "attribute": "http://purl.org/dc/terms/created",
+                "value": "2023-01-01",
+            },
+        ],
+        "search_entities": [
+            {
+                "entity": "urn:example:entity:1",
+                "label": "Example Entity",
+                "score": 0.98,
+                "snippet": "Example snippet",
+            }
+        ],
+        "lineage_by_id": [
+            {
+                "source": "urn:example:entity:1",
+                "relation": "http://www.w3.org/ns/prov#used",
+                "target": "urn:example:artifact:2",
+                "timestamp": {"value": "2023-01-02T00:00:00Z", "datatype": "http://www.w3.org/2001/XMLSchema#dateTime"},
+            }
+        ],
+    }
+    class FixtureFusekiClient(StubFusekiClient):
+        async def query(self, template, query):  # type: ignore[override]
+            if template.name == "entity_by_id" and "urn:example:entity:1" not in query:
+                return {"head": {"vars": []}, "results": {"bindings": []}}
+            return await super().query(template, query)
+
+    client = FixtureFusekiClient(responses=responses)
+    settings = ApiSettings(
+        fuseki_url=None,
+        host="testserver",
+        port=9001,
+        request_body_limit=32 * 1024,
+        request_timeout_seconds=5.0,
+        concurrency_limit=4,
+        rate_limits=RateLimitConfig(
+            anonymous_per_minute=5,
+            authenticated_per_minute=10,
+            anonymous_burst=2,
+            authenticated_burst=4,
+        ),
+    )
+    api = create_app(settings=settings, registry=registry, fuseki_client=client)
+    return TestClient(api)

--- a/tests/api/test_openapi_schema.py
+++ b/tests/api/test_openapi_schema.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+pytestmark = pytest.mark.enable_socket
+
+
+def test_openapi_schema_matches_routes(app) -> None:
+    spec_path = Path("service/openapi/openapi.yaml")
+    data = yaml.safe_load(spec_path.read_text(encoding="utf-8"))
+    assert data["openapi"].startswith("3.1")
+    spec_paths = set(data["paths"].keys())
+    app_paths = {route.path for route in app.app.routes if getattr(route, "methods", None)}
+    for path in spec_paths:
+        assert path in app_paths, f"Path {path} missing from application routes"
+    assert "/health" in spec_paths
+    assert data["components"]["schemas"]["ProblemDetails"]["type"] == "object"

--- a/tests/api/test_rate_limits.py
+++ b/tests/api/test_rate_limits.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.enable_socket
+
+
+def test_rate_limit_exceeded(app) -> None:
+    for _ in range(5):
+        res = app.get("/v1/search", params={"q": "export"})
+        assert res.status_code == 200
+    res = app.get("/v1/search", params={"q": "export"})
+    assert res.status_code == 429
+    payload = res.json()
+    assert payload["status"] == 429
+    assert "Retry-After" in res.headers
+    assert res.headers["X-RateLimit-Limit"]
+    assert res.headers["X-RateLimit-Remaining"] == "0"

--- a/tests/api/test_route_contracts.py
+++ b/tests/api/test_route_contracts.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.enable_socket
+
+
+def test_health_endpoint(app) -> None:
+    res = app.get("/health")
+    assert res.status_code == 200
+    assert res.json()["status"] == "ok"
+
+
+def test_entity_view_contract(app) -> None:
+    res = app.get("/v1/entities/urn:example:entity:1")
+    assert res.status_code == 200
+    data = res.json()
+    assert data["id"] == "urn:example:entity:1"
+    assert "Example Entity" in data["labels"]
+    assert any(attr["predicate"].endswith("identifier") for attr in data["attributes"])
+
+    missing = app.get("/v1/entities/urn:missing")
+    assert missing.status_code == 404
+    err = missing.json()
+    assert err["status"] == 404
+    assert "trace_id" in err
+
+
+def test_search_contract(app) -> None:
+    res = app.get("/v1/search", params={"q": "example"})
+    assert res.status_code == 200
+    payload = res.json()
+    assert payload["total"] == 1
+    assert payload["results"][0]["score"] == 0.98
+
+
+def test_sparql_proxy_contract(app) -> None:
+    res = app.post(
+        "/v1/sparql",
+        json={"template": "search_entities", "parameters": {"q": "example", "limit": 1, "offset": 0}},
+    )
+    assert res.status_code == 200
+    payload = res.json()
+    assert "head" in payload and "results" in payload
+
+
+def test_lineage_contract(app) -> None:
+    res = app.get("/v1/lineage/urn:example:entity:1")
+    assert res.status_code == 200
+    payload = res.json()
+    assert payload["id"] == "urn:example:entity:1"
+    assert payload["edges"]
+    assert payload["edges"][0]["relation"].endswith("prov#used") or payload["edges"][0]["relation"].endswith("prov#wasDerivedFrom")

--- a/tests/api/test_security_headers.py
+++ b/tests/api/test_security_headers.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import pytest
+
+
+pytestmark = pytest.mark.enable_socket
+
+
+@pytest.mark.parametrize("path", ["/health", "/v1/search?q=x", "/v1/entities/urn:example:entity:1"])
+def test_security_headers_present(app, path: str) -> None:
+    res = app.get(path)
+    assert res.headers["Cache-Control"] == "no-store"
+    assert res.headers["X-Content-Type-Options"] == "nosniff"
+    assert res.headers["Referrer-Policy"] == "no-referrer"
+
+
+def test_docs_has_csp(app) -> None:
+    res = app.get("/docs")
+    assert res.status_code == 200
+    assert "Content-Security-Policy" in res.headers
+
+
+def test_problem_details_headers(app) -> None:
+    res = app.get("/v1/entities/urn:missing")
+    assert res.status_code == 404
+    assert res.headers["X-Request-Id"]
+    assert res.headers["X-Subject"].startswith("ip:")

--- a/tests/api/test_templates_locked.py
+++ b/tests/api/test_templates_locked.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import json
+
+
+def test_registry_templates_exist() -> None:
+    registry_path = Path("service/templates/registry.json")
+    data = json.loads(registry_path.read_text(encoding="utf-8"))
+    for entry in data.values():
+        template_path = Path("service/templates") / entry["file"]
+        assert template_path.exists(), f"Missing template {template_path}"
+        content = template_path.read_text(encoding="utf-8")
+        assert "ORDER BY" in content, f"Template {template_path} must have deterministic ordering"
+        assert "SERVICE" not in content.upper(), f"Template {template_path} must not call remote SERVICE"

--- a/tests/cli/test_api_rbac.py
+++ b/tests/cli/test_api_rbac.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from click.testing import CliRunner
+
+from earCrawler.cli import cli
+
+
+def invoke(args: list[str], user: str) -> int:
+    runner = CliRunner()
+    result = runner.invoke(cli, args, env={"EARCTL_USER": user})
+    return result.exit_code
+
+
+def test_api_commands_require_roles() -> None:
+    assert invoke(["api", "start"], "test_operator") == 0
+    assert invoke(["api", "start"], "test_maintainer") == 0
+    assert invoke(["api", "start"], "test_reader") != 0
+    assert invoke(["api", "stop"], "test_operator") == 0
+    assert invoke(["api", "smoke"], "test_operator") == 0


### PR DESCRIPTION
## Summary
- add a FastAPI-based read-only Fuseki facade with request budgets, rate limiting, and structured problem details
- register vetted SPARQL templates, publish an OpenAPI 3.1 spec, docs, and Windows service wrapper scripts
- extend CI with api-surface coverage plus offline API and RBAC tests

## Testing
- pytest tests/api -q
- pytest tests/cli/test_api_rbac.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e5caba6a24832588d571c96c6d03cc