### PR TITLE
Fix PowerShell fallback for API CLI

### DIFF
--- a/tests/cli/test_api_service.py
+++ b/tests/cli/test_api_service.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from earCrawler.cli import api_service
+
+
+def test_invoke_falls_back_to_windows_powershell(monkeypatch) -> None:
+    fallback = "C:/Windows/System32/WindowsPowerShell/v1.0/powershell.exe"
+
+    monkeypatch.setattr(api_service.platform, "system", lambda: "Windows")
+
+    def fake_which(name: str) -> str | None:
+        if name == "pwsh":
+            return None
+        if name == "powershell":
+            return fallback
+        return None
+
+    monkeypatch.setattr(api_service.shutil, "which", fake_which)
+
+    captured: dict[str, list[str]] = {}
+
+    def fake_run(cmd: list[str], check: bool) -> None:
+        captured["cmd"] = cmd
+
+    monkeypatch.setattr(api_service.subprocess, "run", fake_run)
+
+    api_service._invoke("api-start.ps1")
+
+    cmd = captured["cmd"]
+    assert cmd[0] == fallback
+    assert Path(cmd[3]).name == "api-start.ps1"


### PR DESCRIPTION
## Summary
- ensure the API CLI resolves an available PowerShell executable on Windows and provide an override
- add a regression test covering the Windows PowerShell fallback behaviour

## Testing
- `pytest tests/cli/test_api_rbac.py tests/cli/test_api_service.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68e5d21e32f883259838008fe58bc921