### PR TITLE
Fix PowerShell Host parameter conflicts in API scripts

### DIFF
--- a/scripts/api-smoke.ps1
+++ b/scripts/api-smoke.ps1
@@ -1,10 +1,11 @@
 param(
-    [string]$Host = $env:EARCRAWLER_API_HOST ?? '127.0.0.1',
+    [Alias('Host')]
+    [string]$ApiHost = $env:EARCRAWLER_API_HOST ?? '127.0.0.1',
     [int]$Port = [int]($env:EARCRAWLER_API_PORT ?? 9001)
 )
 
 $ErrorActionPreference = 'Stop'
-$base = "http://$Host:$Port"
+$base = "http://$ApiHost:$Port"
 $reportDir = 'kg/reports'
 New-Item -ItemType Directory -Force -Path $reportDir | Out-Null
 $reportFile = Join-Path $reportDir 'api-smoke.txt'

--- a/scripts/api-start.ps1
+++ b/scripts/api-start.ps1
@@ -1,12 +1,13 @@
 param(
-    [string]$Host = $env:EARCRAWLER_API_HOST,
+    [Alias('Host')]
+    [string]$ApiHost = $env:EARCRAWLER_API_HOST,
     [int]$Port,
     [string]$FusekiUrl = $env:EARCRAWLER_FUSEKI_URL
 )
 
 $ErrorActionPreference = 'Stop'
 
-if (-not $Host) { $Host = '127.0.0.1' }
+if (-not $ApiHost) { $ApiHost = '127.0.0.1' }
 
 if (-not $PSBoundParameters.ContainsKey('Port')) {
     if ($env:EARCRAWLER_API_PORT) {
@@ -16,7 +17,7 @@ if (-not $PSBoundParameters.ContainsKey('Port')) {
     }
 }
 
-$env:EARCRAWLER_API_HOST = $Host
+$env:EARCRAWLER_API_HOST = $ApiHost
 $env:EARCRAWLER_API_PORT = $Port
 if ($FusekiUrl) {
     $env:EARCRAWLER_FUSEKI_URL = $FusekiUrl
@@ -29,11 +30,11 @@ $python = (Get-Command python).Source
 $pidFile = Join-Path -Path 'kg/reports' -ChildPath 'api.pid'
 New-Item -ItemType Directory -Force -Path (Split-Path $pidFile) | Out-Null
 
-Write-Host ("Starting EarCrawler API on {0}:{1}" -f $Host, $Port)
-$process = Start-Process -FilePath $python -ArgumentList '-m','uvicorn','service.api_server.server:app','--host',$Host,'--port',$Port -PassThru -WindowStyle Hidden
+Write-Host ("Starting EarCrawler API on {0}:{1}" -f $ApiHost, $Port)
+$process = Start-Process -FilePath $python -ArgumentList '-m','uvicorn','service.api_server.server:app','--host',$ApiHost,'--port',$Port -PassThru -WindowStyle Hidden
 $process.Id | Out-File -FilePath $pidFile -Encoding ascii
 
-$healthUrl = "http://{0}:{1}/health" -f $Host, $Port
+$healthUrl = "http://{0}:{1}/health" -f $ApiHost, $Port
 $deadline = (Get-Date).AddSeconds(20)
 while ((Get-Date) -lt $deadline) {
     try {


### PR DESCRIPTION
## Summary
- avoid using the reserved `$Host` variable in the API PowerShell scripts to prevent runtime errors
- keep CLI compatibility by aliasing the updated parameters while continuing to honor API host environment overrides

## Testing
- pytest tests/cli/test_api_rbac.py
- pytest tests/cli/test_api_service.py

------
https://chatgpt.com/codex/tasks/task_e_68e5d409e7008325aef66a10cfc11d07