### PR TITLE
Add uvicorn dependency for API service

### DIFF
--- a/requirements-gpu.txt
+++ b/requirements-gpu.txt
@@ -13,3 +13,4 @@ pyshacl==0.30.1
 SPARQLWrapper==2.0.0
 torch==2.3.0
 accelerate
+uvicorn==0.31.1

--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -92,7 +92,13 @@ charset-normalizer==3.4.3 \
 click==8.2.1 \
     --hash=sha256:27c491cc05d968d271d5a1db13e3b5a184636d9d930f148c50b038f0d0646202 \
     --hash=sha256:61a3265b914e850b85317d0b3109c7f8cd35a670f963866005d6ef1d5175a12b
-    # via -r requirements.in
+    # via
+    #   -r requirements.in
+    #   uvicorn
+h11==0.16.0 \
+    --hash=sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1 \
+    --hash=sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86
+    # via uvicorn
 idna==3.10 \
     --hash=sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9 \
     --hash=sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3
@@ -217,3 +223,7 @@ urllib3==2.5.0 \
     --hash=sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760 \
     --hash=sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc
     # via requests
+uvicorn==0.31.1 \
+    --hash=sha256:adc42d9cac80cf3e51af97c1851648066841e7cfb6993a4ca8de29ac1548ed41 \
+    --hash=sha256:f5167919867b161b7bcaf32646c6a94cdbd4c3aa2eb5c17d36bb9aa5cfd8c493
+    # via -r requirements.in

--- a/requirements-win-lock.txt
+++ b/requirements-win-lock.txt
@@ -92,7 +92,13 @@ charset-normalizer==3.4.3 \
 click==8.2.1 \
     --hash=sha256:27c491cc05d968d271d5a1db13e3b5a184636d9d930f148c50b038f0d0646202 \
     --hash=sha256:61a3265b914e850b85317d0b3109c7f8cd35a670f963866005d6ef1d5175a12b
-    # via -r requirements.in
+    # via
+    #   -r requirements.in
+    #   uvicorn
+h11==0.16.0 \
+    --hash=sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1 \
+    --hash=sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86
+    # via uvicorn
 idna==3.10 \
     --hash=sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9 \
     --hash=sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3
@@ -217,3 +223,7 @@ urllib3==2.5.0 \
     --hash=sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760 \
     --hash=sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc
     # via requests
+uvicorn==0.31.1 \
+    --hash=sha256:adc42d9cac80cf3e51af97c1851648066841e7cfb6993a4ca8de29ac1548ed41 \
+    --hash=sha256:f5167919867b161b7bcaf32646c6a94cdbd4c3aa2eb5c17d36bb9aa5cfd8c493
+    # via -r requirements.in

--- a/requirements.in
+++ b/requirements.in
@@ -2,3 +2,4 @@ requests==2.31.0
 click==8.2.1
 pytest==8.4.1
 rapidfuzz==3.6.1
+uvicorn==0.31.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ rdflib==6.3.2
 pyshacl==0.25.0
 SPARQLWrapper==2.0.0
 rapidfuzz==3.6.1
+uvicorn==0.31.1
 
 black==24.4.2
 flake8==7.1.0


### PR DESCRIPTION
## Summary
- add uvicorn as a dependency so the API PowerShell scripts can launch the FastAPI service on Windows
- regenerate the requirement lock files to capture the new dependency and its transitive packages

## Testing
- pytest tests/cli/test_api_rbac.py -vv
- pytest tests/cli/test_api_service.py -vv

------
https://chatgpt.com/codex/tasks/task_e_68e5d50357ec832599f8c9fb10ff796b