### PR TITLE
Ensure Windows API start command uses invoking interpreter

### DIFF
--- a/earCrawler/cli/api_service.py
+++ b/earCrawler/cli/api_service.py
@@ -4,6 +4,7 @@ import os
 import platform
 import shutil
 import subprocess
+import sys
 from pathlib import Path
 from typing import Iterable
 
@@ -49,7 +50,9 @@ def _invoke(script: str, args: Iterable[str] = ()) -> None:
     cmd = _resolve_powershell()
     cmd.append(str(script_path))
     cmd.extend(args)
-    subprocess.run(cmd, check=True)
+    env = os.environ.copy()
+    env.setdefault("EARCTL_PYTHON", sys.executable)
+    subprocess.run(cmd, check=True, env=env)
 
 
 @click.group()

--- a/scripts/api-start.ps1
+++ b/scripts/api-start.ps1
@@ -26,7 +26,10 @@ if ($FusekiUrl) {
 }
 $env:EARCRAWLER_API_EMBEDDED_FIXTURE = '1'
 
-$python = (Get-Command python).Source
+$python = $env:EARCTL_PYTHON
+if (-not $python) {
+    $python = (Get-Command python).Source
+}
 $pidFile = Join-Path -Path 'kg/reports' -ChildPath 'api.pid'
 New-Item -ItemType Directory -Force -Path (Split-Path $pidFile) | Out-Null
 


### PR DESCRIPTION
## Summary
- ensure the CLI passes the active Python executable to the PowerShell API helpers via the EARCTL_PYTHON environment variable
- update the API start PowerShell script to honor EARCTL_PYTHON before falling back to locating python on PATH

## Testing
- pytest tests/cli/test_api_rbac.py -vv

------
https://chatgpt.com/codex/tasks/task_e_68e5d6c3daac83258bb24f43337de153