### PR TITLE
RunPass9: complete Phase 5.2/5.3 evidence and quarantine decision package

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ If you are new to the repo, use this rule first:
 - The training-input contract for this model work is recorded in `docs/model_training_contract.md`; it uses approved eCFR snapshot text and the derived retrieval corpus, not eval fixtures or benchmark artifacts.
 - Training scripts and artifacts are still a phase-gated workflow, not a supported operator runtime path by themselves.
 - Task 5.4 adds a separate optional runtime path that can load a Task 5.3 adapter through `/v1/rag/answer` only when `LLM_PROVIDER=local_adapter`, `EARCRAWLER_ENABLE_LOCAL_LLM=1`, and the recorded adapter artifacts are present.
+- The minimum release evidence bundle for a local-adapter candidate is defined in `docs/local_adapter_release_evidence.md` and `config/local_adapter_release_evidence.example.json`.
 - Phase 6 benchmark planning is now recorded in `docs/production_candidate_benchmark_plan.md`; benchmark execution still depends on a real Task 5.3 run artifact and a benchmark runner that targets the local-adapter runtime.
 - Capability-specific promotion and rollback boundaries for text search, hybrid ranking, KG expansion, and local-adapter serving are tracked in `docs/capability_graduation_boundaries.md`.
 
@@ -266,6 +267,15 @@ Then run the operator smoke helper against the same run artifact:
 
 ```powershell
 pwsh .\scripts\local_adapter_smoke.ps1 -RunDir dist/training/<run_id>
+```
+
+Validate the minimum release evidence bundle for that same candidate:
+
+```powershell
+py -m scripts.eval.validate_local_adapter_release_bundle `
+  --run-dir dist/training/<run_id> `
+  --benchmark-summary dist/benchmarks/<benchmark_run_id>/benchmark_summary.json `
+  --smoke-report kg/reports/local-adapter-smoke.json
 ```
 
 Call the generated-answer endpoint:

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -28,7 +28,11 @@
    - `pwsh scripts/verify-release.ps1 -RequireSignedExecutables -RequireCompleteEvidence -ApiSmokeReportPath dist\api_smoke.json -OptionalRuntimeSmokeReportPath dist\optional_runtime_smoke.json -InstalledRuntimeSmokeReportPath dist\installed_runtime_smoke.json -EvidenceOutPath dist\release_validation_evidence.json`
 13. If a real Task 5.3 run artifact is available, run:
    - `pwsh scripts/optional-runtime-smoke.ps1 -Host 127.0.0.1 -Port 9001 -LocalAdapterRunDir dist\training\<run_id> -ReportPath dist\optional_runtime_smoke.json`
-14. Create a GitHub release and upload the wheel, EXE, installer, checksum, SBOM, `dist\api_smoke.json`, `dist\installed_runtime_smoke.json`, release validation evidence, and optional runtime smoke evidence files.
+14. If a real Task 5.3 run artifact is available, validate its release evidence bundle:
+   - `pwsh scripts/local_adapter_smoke.ps1 -RunDir dist\training\<run_id>`
+   - `py -m scripts.eval.run_local_adapter_benchmark --run-dir dist\training\<run_id> --manifest eval\manifest.json --dataset-id ear_compliance.v2 --dataset-id entity_obligations.v2 --dataset-id unanswerable.v2 --smoke-report kg\reports\local-adapter-smoke.json`
+   - `py -m scripts.eval.validate_local_adapter_release_bundle --run-dir dist\training\<run_id> --benchmark-summary dist\benchmarks\<benchmark_run_id>\benchmark_summary.json --smoke-report kg\reports\local-adapter-smoke.json`
+15. Create a GitHub release and upload the wheel, EXE, installer, checksum, SBOM, `dist\api_smoke.json`, `dist\installed_runtime_smoke.json`, release validation evidence, and optional runtime smoke evidence files.
 
 Release artifact note
 - The wheel is the authoritative deployment artifact for the supported Windows API service path described in `docs/ops/windows_single_host_operator.md`.
@@ -56,6 +60,7 @@ Windows notes
 - Machine-readable capability state is published at `docs/api/capability_registry.json` (generated from `service/docs/capability_registry.json`). `README.md` remains the human-readable summary.
 - Supported API routes are `/health`, `/v1/entities/{entity_id}`, `/v1/lineage/{entity_id}`, `/v1/sparql`, and `/v1/rag/query`.
 - Optional API/runtime features require explicit enablement: `/v1/rag/answer`, remote OpenAI-compatible providers, retrieval extras installed from `requirements-gpu.txt`, `EARCRAWLER_RETRIEVAL_MODE=hybrid`, and the Task 5.4 local adapter runtime (`LLM_PROVIDER=local_adapter` plus explicit local-model env).
+- The minimum optional local-adapter release bundle is defined in `docs/local_adapter_release_evidence.md` and `config/local_adapter_release_evidence.example.json`.
 - Quarantined runtime features include `/v1/search`, text-backed Fuseki search, `kg-load`, `kg-serve`, `kg-query`, and KG expansion.
 - `/v1/search` is disabled by default at runtime; enable only for local validation with `EARCRAWLER_API_ENABLE_SEARCH=1`.
 - Hybrid ranking and local-adapter serving are tracked separately from KG quarantine in `docs/capability_graduation_boundaries.md`.

--- a/config/local_adapter_release_evidence.example.json
+++ b/config/local_adapter_release_evidence.example.json
@@ -1,0 +1,66 @@
+{
+  "schema_version": "local-adapter-release-evidence-contract.v1",
+  "status": "optional_until_bundle_passes",
+  "capability_id": "runtime.local_adapter_serving",
+  "bundle": {
+    "provenance_manifest": "dist/training/<run_id>/release_evidence_manifest.json",
+    "required_run_files": [
+      "manifest.json",
+      "run_config.json",
+      "run_metadata.json",
+      "inference_smoke.json",
+      "adapter/adapter_config.json",
+      "adapter/tokenizer_config.json"
+    ],
+    "required_benchmark_files": [
+      "benchmark_manifest.json",
+      "benchmark_summary.json",
+      "benchmark_summary.md",
+      "benchmark_artifacts.json"
+    ],
+    "required_primary_datasets": [
+      "ear_compliance.v2",
+      "entity_obligations.v2",
+      "unanswerable.v2"
+    ],
+    "rollback_docs": [
+      "docs/local_adapter_release_evidence.md",
+      "docs/capability_graduation_boundaries.md",
+      "docs/ops/windows_single_host_operator.md"
+    ]
+  },
+  "thresholds": {
+    "answer_accuracy_min": 0.65,
+    "label_accuracy_min": 0.8,
+    "unanswerable_accuracy_min": 0.9,
+    "valid_citation_rate_min": 0.95,
+    "supported_rate_min": 0.9,
+    "overclaim_rate_max": 0.05,
+    "strict_output_failure_rate_max": 0.0,
+    "request_422_rate_max": 0.0,
+    "request_503_rate_max": 0.0,
+    "latency_p95_ms_max": 15000
+  },
+  "comparison_rules": {
+    "require_retrieval_only_condition": true,
+    "answer_accuracy_gte_retrieval_only": true,
+    "supported_rate_gte_retrieval_only": true,
+    "overclaim_rate_lte_retrieval_only": true
+  },
+  "decision_rule": {
+    "keep_optional_when": [
+      "Any required artifact or rollback document is missing.",
+      "The Task 5.3 run manifest does not record snapshot id, snapshot hash, and retrieval corpus digest.",
+      "Either inference_smoke.json or scripts/local_adapter_smoke.ps1 evidence is missing or non-passing.",
+      "The benchmark bundle omits any required primary dataset or violates a threshold in this contract.",
+      "The local_adapter condition performs worse than retrieval_only on a required comparison rule."
+    ],
+    "ready_for_formal_promotion_review_when": [
+      "The evidence bundle is complete.",
+      "All thresholds pass.",
+      "The benchmark bundle includes retrieval_only control data and required primary datasets.",
+      "A dated promotion decision can cite this manifest plus the named rollback docs without changing the baseline runtime."
+    ],
+    "promotion_note": "A passing bundle does not auto-promote local_adapter to Supported. Promotion still requires a dated decision record and updates to the capability registry and operator docs."
+  }
+}

--- a/docs/ExecutionPlanRunPass9.md
+++ b/docs/ExecutionPlanRunPass9.md
@@ -4,6 +4,19 @@ Source: `docs/RunPass9.md` only.
 
 Purpose: preserve the current strengths of the repository while improving the weaknesses and missing components identified in Run Pass 9, with phased execution prompts sized to the actual reasoning required.
 
+## Execution Status (March 19, 2026)
+
+- Phase 1: complete
+- Phase 2: complete
+- Phase 3: complete
+- Phase 4: complete
+- Phase 5.1: complete
+- Phase 5.2: complete (real candidate validated at
+  `dist/training/step52-real-candidate-gpt2b-20260319/`; decision:
+  `keep_optional`)
+- Phase 5.3: complete (dated search/KG evidence bundle generated on March 19,
+  2026; recommendation: `Keep Quarantined`)
+
 Reasoning-level guidance:
 - Prefer `medium` for bounded code or documentation alignment work.
 - Prefer `high` for cross-file implementation, architecture alignment, or evidence-package work.
@@ -178,3 +191,4 @@ Prompt:
 ```text
 Use docs/ExecutionPlanRunPass9.md and the completed outputs from each prior phase as the governing context. Perform a fresh, comprehensive repository review with the explicit goal of determining whether EAR AI / earCrawler now qualifies as a production beta baseline. Evaluate whether the repo preserved the strengths identified in RunPass9, whether the listed weaknesses and missing components were actually resolved or only partially addressed, whether supported-vs-optional-vs-quarantined boundaries are now consistent across code, tests, docs, packaging, and operator workflow, and whether the remaining risks are acceptable for a production beta designation. Be precise about current maturity, release blockers, residual technical debt, operator gaps, and any capabilities that must remain optional or quarantined. Produce a decision-oriented review document that ends with one of: `Production beta ready`, `Production beta ready with named constraints`, or `Not production beta ready`, and justify that result with concrete evidence.
 ```
+

--- a/docs/capability_graduation_boundaries.md
+++ b/docs/capability_graduation_boundaries.md
@@ -15,6 +15,7 @@ Use this document together with:
 - `docs/kg_unquarantine_plan.md`
 - `docs/hybrid_retrieval_design.md`
 - `docs/model_training_surface_adr.md`
+- `docs/local_adapter_release_evidence.md`
 - `docs/ops/windows_single_host_operator.md`
 
 ## State summary
@@ -156,8 +157,8 @@ Current operator control:
 
 Promotion from `Optional` to `Supported` requires all of the following:
 
-- a retained real-artifact or compact validation-pack contract that can be used
-  in release validation without reconstructing training output manually
+- a passing evidence bundle defined in `docs/local_adapter_release_evidence.md`
+  and validated against `config/local_adapter_release_evidence.example.json`
 - release-gated smoke for the installed-service runtime using that artifact
 - operator docs for artifact placement, health verification, rollback, and
   troubleshooting
@@ -165,6 +166,13 @@ Promotion from `Optional` to `Supported` requires all of the following:
   report archived with release evidence
 - a dated decision record stating whether support remains artifact-by-artifact
   optional or becomes part of the baseline supported deployment
+
+Exact evidence decision rule:
+
+- keep the capability `Optional` when any required artifact, smoke report,
+  benchmark dataset, threshold, or rollback document is missing or failing
+- treat the capability as `Ready for formal promotion review` only when the
+  full evidence bundle passes; this does not auto-promote the capability
 
 ## Governing split
 

--- a/docs/data_artifact_inventory.md
+++ b/docs/data_artifact_inventory.md
@@ -62,6 +62,7 @@ Artifact classes:
 | `dist/training/<run_id>/run_metadata.json` | Generated | Optional training-package review | Run outcome, metrics, and artifact metadata. |
 | `dist/training/<run_id>/adapter/` | Generated | Optional local-adapter runtime candidate | Candidate adapter artifact; optional until promoted by evidence. |
 | `dist/training/<run_id>/inference_smoke.json` | Generated | Optional training/runtime smoke evidence | Smoke-test result for the named adapter run. |
+| `dist/training/<run_id>/release_evidence_manifest.json` | Generated | Optional local-adapter release review | Decision manifest produced from the release-evidence contract; records hashes, thresholds, and review outcome for one adapter candidate. |
 | `dist/benchmarks/` | Generated | Optional benchmark evidence | Benchmark outputs and manifests; evidence only, never input truth. |
 
 ## Practical rules

--- a/docs/local_adapter_release_evidence.md
+++ b/docs/local_adapter_release_evidence.md
@@ -1,0 +1,217 @@
+# Local-Adapter Release Evidence Bundle
+
+Status: active Phase 5 evidence contract for the optional
+`LLM_PROVIDER=local_adapter` runtime path.
+
+This document defines the minimum evidence bundle required before a Task 5.3
+adapter artifact can be treated as a real release candidate for the optional
+local-adapter serving path. It does not change the supported baseline runtime,
+and it does not promote the capability by itself.
+
+Use this document together with:
+
+- `config/local_adapter_release_evidence.example.json`
+- `docs/model_training_first_pass.md`
+- `docs/production_candidate_benchmark_plan.md`
+- `docs/capability_graduation_boundaries.md`
+- `docs/ops/windows_single_host_operator.md`
+
+## Goal
+
+Make local-adapter release claims artifact-backed and reproducible.
+
+The minimum bundle must prove all of the following for one named
+`dist/training/<run_id>/` candidate:
+
+- which adapter artifact is under review
+- which snapshot and retrieval corpus produced it
+- which benchmark outputs were used to judge it
+- whether the supported optional runtime path still works through
+  `/v1/rag/answer`
+- how to roll the host back if the candidate is rejected
+
+## Required bundle contents
+
+For a candidate run directory `dist/training/<run_id>/`, the minimum bundle is:
+
+1. Adapter artifact and Task 5.3 run metadata
+   - `dist/training/<run_id>/adapter/`
+   - `dist/training/<run_id>/manifest.json`
+   - `dist/training/<run_id>/run_config.json`
+   - `dist/training/<run_id>/run_metadata.json`
+   - `dist/training/<run_id>/inference_smoke.json`
+2. Provenance manifest for the release review
+   - `dist/training/<run_id>/release_evidence_manifest.json`
+   - Produced by `py -m scripts.eval.validate_local_adapter_release_bundle ...`
+   - This manifest records file hashes, corpus digest, benchmark references,
+     threshold results, and the final decision label
+3. Runtime smoke
+   - `kg/reports/local-adapter-smoke.json` from
+     `pwsh .\scripts\local_adapter_smoke.ps1 -RunDir dist/training/<run_id>`
+4. Benchmark bundle
+   - `dist/benchmarks/<benchmark_run_id>/benchmark_manifest.json`
+   - `dist/benchmarks/<benchmark_run_id>/benchmark_summary.json`
+   - `dist/benchmarks/<benchmark_run_id>/benchmark_summary.md`
+   - `dist/benchmarks/<benchmark_run_id>/benchmark_artifacts.json`
+5. Rollback instructions
+   - this document
+   - `docs/capability_graduation_boundaries.md`
+   - `docs/ops/windows_single_host_operator.md`
+
+If any item above is missing, the evidence is insufficient and the capability
+stays `Optional`.
+
+## Provenance requirements
+
+The candidate bundle must preserve the same authoritative text-and-retrieval
+truth chain already used elsewhere in the repo.
+
+`dist/training/<run_id>/manifest.json` must record at least:
+
+- `run_id`
+- `base_model`
+- `snapshot_id`
+- `snapshot_sha256`
+- `retrieval_corpus_path`
+- `retrieval_corpus_digest`
+- `retrieval_corpus_doc_count`
+- `training_input_contract_path`
+- `index_meta_path`
+
+The release-evidence validator copies these facts into
+`release_evidence_manifest.json` and adds SHA-256 hashes for the benchmark
+summary and smoke report so the review bundle can be archived and compared
+later.
+
+## Benchmark requirements
+
+Use the benchmark runner from `docs/production_candidate_benchmark_plan.md`:
+
+```powershell
+py -m scripts.eval.run_local_adapter_benchmark `
+  --run-dir dist/training/<run_id> `
+  --manifest eval/manifest.json `
+  --dataset-id ear_compliance.v2 `
+  --dataset-id entity_obligations.v2 `
+  --dataset-id unanswerable.v2 `
+  --smoke-report kg/reports/local-adapter-smoke.json
+```
+
+The benchmark bundle must include:
+
+- aggregate `local_adapter` metrics
+- aggregate `retrieval_only` control metrics
+- all three primary datasets:
+  - `ear_compliance.v2`
+  - `entity_obligations.v2`
+  - `unanswerable.v2`
+
+## Minimum thresholds
+
+The contract threshold file is `config/local_adapter_release_evidence.example.json`.
+
+The current minimum benchmark thresholds for the `local_adapter` aggregate are:
+
+- `answer_accuracy >= 0.65`
+- `label_accuracy >= 0.80`
+- `unanswerable_accuracy >= 0.90`
+- `valid_citation_rate >= 0.95`
+- `supported_rate >= 0.90`
+- `overclaim_rate <= 0.05`
+- `strict_output_failure_rate == 0.0`
+- `request_422_rate == 0.0`
+- `request_503_rate == 0.0`
+- `latency_ms.p95 <= 15000`
+
+The release bundle must also carry a retrieval-only control, and the
+`local_adapter` condition must:
+
+- meet or exceed retrieval-only `answer_accuracy`
+- meet or exceed retrieval-only `supported_rate`
+- not exceed retrieval-only `overclaim_rate`
+
+These thresholds are intentionally strict enough to block a candidate that is
+artifact-complete but still operationally weak.
+
+## Runtime smoke requirements
+
+Two smoke layers are required:
+
+1. `inference_smoke.json`
+   - proves the Task 5.3 adapter can still load against the named base model
+2. `kg/reports/local-adapter-smoke.json`
+   - proves the supported optional `/v1/rag/answer` runtime path still works
+   - proves `provider=local_adapter`
+   - proves remote egress remains disabled in local-adapter mode
+
+If either smoke report is missing or non-passing, the evidence is insufficient.
+
+## Rollback expectation
+
+The rollback story for local-adapter release candidates is intentionally small:
+
+1. Remove or clear the local-adapter env on the host:
+   - `LLM_PROVIDER`
+   - `EARCRAWLER_ENABLE_LOCAL_LLM`
+   - `EARCRAWLER_LOCAL_LLM_BASE_MODEL`
+   - `EARCRAWLER_LOCAL_LLM_ADAPTER_DIR`
+   - `EARCRAWLER_LOCAL_LLM_MODEL_ID`
+2. Restart the API service.
+3. Re-run `/health` plus supported API smoke.
+4. Confirm the host capability posture is back to the baseline default:
+   - search `Quarantined`
+   - KG expansion `Quarantined`
+   - retrieval mode `dense`
+   - no active local-adapter env
+
+If a wheel or host config change accompanied the candidate, use the broader host
+rollback procedure in `docs/ops/windows_single_host_operator.md`.
+
+## Validation command
+
+Validate the minimum release bundle with:
+
+```powershell
+py -m scripts.eval.validate_local_adapter_release_bundle `
+  --run-dir dist/training/<run_id> `
+  --benchmark-summary dist/benchmarks/<benchmark_run_id>/benchmark_summary.json `
+  --smoke-report kg/reports/local-adapter-smoke.json
+```
+
+Default behavior:
+
+- reads `config/local_adapter_release_evidence.example.json`
+- writes `dist/training/<run_id>/release_evidence_manifest.json`
+- exits non-zero when evidence is incomplete or thresholds fail
+
+## Decision rule
+
+The decision rule is exact:
+
+- `Keep Optional`
+  - if any required artifact is missing
+  - if any smoke report fails
+  - if any required dataset is missing from the benchmark bundle
+  - if any threshold fails
+  - if the candidate underperforms the retrieval-only control on a required
+    comparison rule
+- `Ready for formal promotion review`
+  - only when the full bundle exists and all checks pass
+
+Passing this contract does not directly change the capability state to
+`Supported`. Promotion still requires a dated decision record plus updates to
+the capability registry and operator docs.
+
+## What counts as insufficient evidence
+
+Examples of insufficient evidence:
+
+- adapter files exist, but no benchmark bundle exists
+- benchmark bundle exists, but `retrieval_only` control data is missing
+- `manifest.json` is missing `retrieval_corpus_digest`
+- `local-adapter-smoke.json` is missing or non-passing
+- citation/support metrics pass, but overclaim exceeds the max threshold
+- metrics are acceptable, but rollback docs are not named and archived
+
+Any of the above means the local-adapter path may remain implemented in source,
+but it is not ready to be promoted beyond the current `Optional` state.

--- a/docs/model_training_first_pass.md
+++ b/docs/model_training_first_pass.md
@@ -68,6 +68,15 @@ pwsh .\scripts\local_adapter_smoke.ps1 `
   -RunDir dist/training/<run_id>
 ```
 
+Release-evidence bundle validation:
+
+```powershell
+py -m scripts.eval.validate_local_adapter_release_bundle `
+  --run-dir dist/training/<run_id> `
+  --benchmark-summary dist/benchmarks/<benchmark_run_id>/benchmark_summary.json `
+  --smoke-report kg/reports/local-adapter-smoke.json
+```
+
 ## Runtime expectations
 
 - `--prepare-only` is CPU-safe and only builds deterministic package artifacts.
@@ -98,6 +107,8 @@ Output layout:
 - `dist/training/<run_id>/run_metadata.json`
 - `dist/training/<run_id>/adapter/` (LoRA artifact)
 - `dist/training/<run_id>/inference_smoke.json`
+- `dist/training/<run_id>/release_evidence_manifest.json` (created only when the
+  optional release bundle is validated)
 
 ## Metadata contract (Task 5.3)
 
@@ -118,6 +129,13 @@ Output layout:
 - training metrics
 - inference smoke report path
 
+`inference_smoke.json` records at least:
+
+- `base_model`
+- `adapter_dir`
+- smoke prompt and generated completion
+- pass/fail result
+
 ## Notes
 
 - This workflow is a Phase 5 training workflow, not an operator runtime command.
@@ -132,6 +150,10 @@ Output layout:
   before it will serve the adapter.
 - Use `scripts/local_adapter_smoke.ps1` to verify the configured API path still
   enforces strict output/schema and egress expectations in local-adapter mode.
+- Use `docs/local_adapter_release_evidence.md` and
+  `config/local_adapter_release_evidence.example.json` to decide whether a
+  concrete run artifact has enough evidence to stay `Optional` or move to a
+  formal promotion review.
 - A real end-to-end local-adapter smoke still requires a concrete
   `dist/training/<run_id>/` artifact from Task 5.3. If that artifact is not
   present in the current checkout, the smoke remains a documented prerequisite,

--- a/docs/model_training_surface_adr.md
+++ b/docs/model_training_surface_adr.md
@@ -96,6 +96,28 @@ The key decisions are:
 - a local KG is optional provenance metadata, not a hard prerequisite for the
   first fine-tuning pass
 
+On March 19, 2026, Step 5.2 was executed against a real local candidate under
+`dist/training/step52-real-candidate-gpt2b-20260319/` using:
+
+- `scripts/training/run_phase5_finetune.py` (real adapter + metadata output)
+- `scripts/eval/run_local_adapter_benchmark.py` (benchmark bundle generation)
+- `scripts/eval/validate_local_adapter_release_bundle.py` (release-evidence
+  decision manifest)
+
+Recorded evidence artifacts:
+
+- `dist/training/step52-real-candidate-gpt2b-20260319/manifest.json`
+- `dist/training/step52-real-candidate-gpt2b-20260319/run_metadata.json`
+- `dist/training/step52-real-candidate-gpt2b-20260319/inference_smoke.json`
+- `dist/benchmarks/step52-real-candidate-gpt2b-20260319/benchmark_summary.json`
+- `dist/training/step52-real-candidate-gpt2b-20260319/release_evidence_manifest.json`
+
+The validator decision for this concrete candidate was `keep_optional`, which
+is expected for the current workspace evidence set and does not promote the
+local-adapter capability. In this workspace, the runtime smoke failed with
+`Retriever not ready`, so the evidence package records a non-passing runtime
+precondition.
+
 ## Phase 5.3 First Fine-Tuning Pass Record
 
 On March 11, 2026, Task 5.3 added a repeatable first-pass fine-tuning workflow

--- a/docs/ops/release_process.md
+++ b/docs/ops/release_process.md
@@ -20,13 +20,23 @@ This document describes reproducible KG release steps.
    - `scripts/api-stop.ps1`
 11. Run release-shaped optional-mode smoke coverage:
    - `scripts/optional-runtime-smoke.ps1 -Host 127.0.0.1 -Port 9001 -SkipLocalAdapter -ReportPath dist/optional_runtime_smoke.json`
-12. If a real Task 5.3 run artifact is available, run the same smoke with local-adapter validation:
+12. If a real Task 5.3 run artifact is available, produce the local-adapter evidence bundle:
+   - `scripts/local_adapter_smoke.ps1 -RunDir dist/training/<run_id>`
+   - `py -m scripts.eval.run_local_adapter_benchmark --run-dir dist/training/<run_id> --manifest eval/manifest.json --dataset-id ear_compliance.v2 --dataset-id entity_obligations.v2 --dataset-id unanswerable.v2 --smoke-report kg/reports/local-adapter-smoke.json`
+   - `py -m scripts.eval.validate_local_adapter_release_bundle --run-dir dist/training/<run_id> --benchmark-summary dist/benchmarks/<benchmark_run_id>/benchmark_summary.json --smoke-report kg/reports/local-adapter-smoke.json`
+13. If a real Task 5.3 run artifact is available, run the same optional-runtime smoke with local-adapter validation:
    - `scripts/optional-runtime-smoke.ps1 -Host 127.0.0.1 -Port 9001 -LocalAdapterRunDir dist/training/<run_id> -ReportPath dist/optional_runtime_smoke.json`
-13. Use `scripts/verify-release.ps1` to validate canonical + distributable artifacts and emit evidence:
+14. Use `scripts/verify-release.ps1` to validate canonical + distributable artifacts and emit evidence:
    - `scripts/verify-release.ps1 -RequireSignedExecutables -RequireCompleteEvidence -ApiSmokeReportPath dist/api_smoke.json -OptionalRuntimeSmokeReportPath dist/optional_runtime_smoke.json -InstalledRuntimeSmokeReportPath dist/installed_runtime_smoke.json -EvidenceOutPath dist/release_validation_evidence.json`
    - validation now fails if any distributable output still includes files with `PLACEHOLDER` in the filename (for example `manifest.sig.PLACEHOLDER.txt` in `dist/offline_bundle/`)
    - publication now also fails if the canonical manifest signature, release checksums signature, supported API smoke report, optional-runtime smoke report, or installed-runtime smoke report are missing or non-passing
-14. Archive `dist/api_smoke.json`, `dist/installed_runtime_smoke.json`, `dist/release_validation_evidence.json`, and `dist/optional_runtime_smoke.json` with the release bundle.
+15. Archive `dist/api_smoke.json`, `dist/installed_runtime_smoke.json`, `dist/release_validation_evidence.json`, and `dist/optional_runtime_smoke.json` with the release bundle.
+
+Optional local-adapter note:
+- A passing `release_evidence_manifest.json` keeps one named adapter candidate
+  evidence-backed and reviewable, but it does not auto-promote the capability
+  beyond `Optional`. Use `docs/local_adapter_release_evidence.md` for the exact
+  decision rule.
 
 Single-host support note:
 - Release evidence should always map to the supported deployment contract: one

--- a/docs/ops/windows_single_host_operator.md
+++ b/docs/ops/windows_single_host_operator.md
@@ -437,6 +437,28 @@ pwsh scripts/optional-runtime-smoke.ps1 `
   -ReportPath C:\ProgramData\EarCrawler\workspace\kg\reports\optional-runtime-smoke.json
 ```
 
+For a release-candidate adapter, also retain the evidence bundle defined in
+`docs/local_adapter_release_evidence.md`:
+
+```powershell
+pwsh scripts\local_adapter_smoke.ps1 `
+  -RunDir C:\ProgramData\EarCrawler\models\<run_id>
+py -m scripts.eval.run_local_adapter_benchmark `
+  --run-dir C:\ProgramData\EarCrawler\models\<run_id> `
+  --manifest eval\manifest.json `
+  --dataset-id ear_compliance.v2 `
+  --dataset-id entity_obligations.v2 `
+  --dataset-id unanswerable.v2 `
+  --smoke-report kg\reports\local-adapter-smoke.json
+py -m scripts.eval.validate_local_adapter_release_bundle `
+  --run-dir C:\ProgramData\EarCrawler\models\<run_id> `
+  --benchmark-summary dist\benchmarks\<benchmark_run_id>\benchmark_summary.json `
+  --smoke-report kg\reports\local-adapter-smoke.json
+```
+
+Keep the resulting `release_evidence_manifest.json` with the host-local release
+evidence for that candidate.
+
 Rollback for optional/quarantined local validation modes:
 
 ```powershell

--- a/docs/search_kg_quarantine_review_2026-03-19.md
+++ b/docs/search_kg_quarantine_review_2026-03-19.md
@@ -1,0 +1,72 @@
+# Search/KG Quarantine Review
+
+Decision date: March 19, 2026
+
+Recommendation: `Keep Quarantined`
+
+Inputs:
+
+- `docs/RunPass9.md`
+- `docs/kg_quarantine_exit_gate.md`
+- `docs/kg_unquarantine_plan.md`
+- `docs/capability_graduation_boundaries.md`
+- `dist/search_kg_evidence/search_kg_evidence_bundle.json`
+- `dist/search_kg_evidence/search_kg_evidence_bundle.md`
+
+## Scope
+
+This review covers only the quarantined runtime surfaces named by the existing
+gate:
+
+- `/v1/search`
+- text-index-backed Fuseki search
+- KG expansion used as a runtime dependency
+
+It does not change support status by itself.
+
+## Current capability snapshot
+
+- `api.search`: `quarantined`
+- `kg.expansion`: `quarantined`
+
+That snapshot still matches the machine-readable capability registry and the
+current operator baseline.
+
+## Fresh evidence used for this review
+
+The Step 5.3 bundle was produced from current workspace artifacts on March 19,
+2026 and captures:
+
+- capability state from `service/docs/capability_registry.json`
+- optional runtime smoke proving search default-off, search opt-in, search
+  rollback, and KG failure-policy behavior
+- installed runtime smoke proving the release-shaped runtime contract still
+  reports search and KG expansion as `quarantined`
+- current release validation evidence status
+
+## Why the recommendation remains Keep Quarantined
+
+The fresh bundle improves evidence quality, but it does not satisfy the
+quarantine exit gate end to end. The specific blockers remain:
+
+1. No operator-owned text-index-enabled Fuseki provisioning and rollback proof
+   is attached for `/v1/search`.
+2. No production-like smoke artifact is attached for `/v1/search` against a
+   real text-index-backed Fuseki runtime path.
+3. No production-like smoke artifact is attached for KG expansion success
+   through the supported runtime shape.
+4. The release validation evidence in this workspace remains incomplete for the
+   full distributable-artifact publication gate.
+5. There is still no dated pass record showing that exit-gate criteria 1
+   through 7 are all satisfied with current evidence.
+
+## Practical conclusion
+
+The repo is in the correct posture:
+
+- search and KG-backed runtime behavior remain implemented and locally
+  testable
+- optional smoke now provides a cleaner evidence input for future review
+- the operator baseline still correctly excludes these surfaces
+
+Within RunPass9 scope, the right decision is still `Keep Quarantined`.

--- a/scripts/eval/build_search_kg_evidence_bundle.py
+++ b/scripts/eval/build_search_kg_evidence_bundle.py
@@ -1,0 +1,478 @@
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import date, datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_CAPABILITY_REGISTRY = REPO_ROOT / "service" / "docs" / "capability_registry.json"
+DEFAULT_OPTIONAL_RUNTIME_SMOKE = REPO_ROOT / "dist" / "optional_runtime_smoke.json"
+DEFAULT_INSTALLED_RUNTIME_SMOKE = REPO_ROOT / "dist" / "installed_runtime_smoke.json"
+DEFAULT_RELEASE_EVIDENCE = REPO_ROOT / "dist" / "release_validation_evidence.json"
+DEFAULT_OUT_JSON = REPO_ROOT / "dist" / "search_kg_evidence" / "search_kg_evidence_bundle.json"
+DEFAULT_OUT_MD = REPO_ROOT / "dist" / "search_kg_evidence" / "search_kg_evidence_bundle.md"
+
+SEARCH_PHASES = ("search_default_off", "search_opt_in_on", "search_rollback_off")
+KG_FAILURE_CHECKS = (
+    "disable_missing_fuseki",
+    "error_missing_fuseki",
+    "json_stub_expansion",
+)
+INSTALLED_RUNTIME_CHECKS = (
+    "runtime_contract_api_search",
+    "runtime_contract_kg_expansion",
+)
+GOVERNING_DOCS = (
+    "docs/RunPass9.md",
+    "docs/kg_quarantine_exit_gate.md",
+    "docs/kg_unquarantine_plan.md",
+    "docs/capability_graduation_boundaries.md",
+    "docs/ops/windows_single_host_operator.md",
+    "docs/ops/release_process.md",
+)
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _write_text(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _rel(path: Path | None) -> str | None:
+    if path is None:
+        return None
+    try:
+        return str(path.resolve().relative_to(REPO_ROOT))
+    except ValueError:
+        return str(path.resolve())
+
+
+def _lookup_capability(registry: Mapping[str, Any], capability_id: str) -> dict[str, Any]:
+    for entry in registry.get("capabilities") or []:
+        if isinstance(entry, Mapping) and str(entry.get("id")) == capability_id:
+            return dict(entry)
+    raise KeyError(f"Capability {capability_id!r} not found in registry.")
+
+
+def _summarize_optional_runtime_smoke(payload: Mapping[str, Any] | None) -> dict[str, Any]:
+    if payload is None:
+        return {
+            "present": False,
+            "status": "missing",
+            "overall_status": "",
+            "search_phase_statuses": {},
+            "missing_search_phases": list(SEARCH_PHASES),
+            "kg_failure_check_statuses": {},
+            "missing_kg_failure_checks": list(KG_FAILURE_CHECKS),
+        }
+
+    search_statuses: dict[str, str] = {}
+    search_phases_raw = payload.get("search_mode_checks") or []
+    if isinstance(search_phases_raw, list):
+        for item in search_phases_raw:
+            if isinstance(item, Mapping):
+                name = str(item.get("name") or "").strip()
+                if name:
+                    search_statuses[name] = str(item.get("status") or "")
+
+    kg_statuses: dict[str, str] = {}
+    kg_raw = payload.get("kg_expansion_failure_policy_checks") or {}
+    if isinstance(kg_raw, Mapping):
+        checks = kg_raw.get("checks") or {}
+        if isinstance(checks, Mapping):
+            for name, item in checks.items():
+                if isinstance(item, Mapping):
+                    kg_statuses[str(name)] = str(item.get("status") or "")
+
+    missing_search = [name for name in SEARCH_PHASES if name not in search_statuses]
+    missing_kg = [name for name in KG_FAILURE_CHECKS if name not in kg_statuses]
+
+    passed = (
+        str(payload.get("schema_version") or "") == "optional-runtime-smoke.v1"
+        and str(payload.get("overall_status") or "") == "passed"
+        and not missing_search
+        and not missing_kg
+        and all(search_statuses.get(name) == "passed" for name in SEARCH_PHASES)
+        and all(kg_statuses.get(name) == "passed" for name in KG_FAILURE_CHECKS)
+    )
+    return {
+        "present": True,
+        "status": "passed" if passed else "failed",
+        "overall_status": str(payload.get("overall_status") or ""),
+        "search_phase_statuses": search_statuses,
+        "missing_search_phases": missing_search,
+        "kg_failure_check_statuses": kg_statuses,
+        "missing_kg_failure_checks": missing_kg,
+    }
+
+
+def _summarize_installed_runtime_smoke(payload: Mapping[str, Any] | None) -> dict[str, Any]:
+    if payload is None:
+        return {
+            "present": False,
+            "status": "missing",
+            "overall_status": "",
+            "check_statuses": {},
+            "missing_checks": list(INSTALLED_RUNTIME_CHECKS),
+            "failed_checks": [],
+        }
+
+    check_statuses: dict[str, bool] = {}
+    checks_raw = payload.get("checks") or []
+    if isinstance(checks_raw, list):
+        for item in checks_raw:
+            if isinstance(item, Mapping):
+                name = str(item.get("name") or "").strip()
+                if name:
+                    check_statuses[name] = bool(item.get("passed"))
+    missing_checks = [name for name in INSTALLED_RUNTIME_CHECKS if name not in check_statuses]
+    failed_checks = [name for name in INSTALLED_RUNTIME_CHECKS if check_statuses.get(name) is False]
+    passed = (
+        str(payload.get("schema_version") or "") == "installed-runtime-smoke.v1"
+        and str(payload.get("overall_status") or "") == "passed"
+        and not missing_checks
+        and not failed_checks
+    )
+    return {
+        "present": True,
+        "status": "passed" if passed else "failed",
+        "overall_status": str(payload.get("overall_status") or ""),
+        "check_statuses": check_statuses,
+        "missing_checks": missing_checks,
+        "failed_checks": failed_checks,
+    }
+
+
+def _summarize_release_evidence(payload: Mapping[str, Any] | None) -> dict[str, Any]:
+    if payload is None:
+        return {
+            "present": False,
+            "status": "missing",
+            "dist_files_verified": 0,
+            "dist_signature_verified": False,
+            "dist_skipped_reason": "missing report",
+            "supported_api_smoke_status": "missing",
+            "optional_runtime_smoke_status": "missing",
+            "installed_runtime_smoke_status": "missing",
+        }
+
+    dist_artifacts = payload.get("dist_artifacts") or {}
+    supported_api_smoke = payload.get("supported_api_smoke") or {}
+    optional_runtime_smoke = payload.get("optional_runtime_smoke") or {}
+    installed_runtime_smoke = payload.get("installed_runtime_smoke") or {}
+    complete = (
+        str(payload.get("schema_version") or "") == "release-validation-evidence.v1"
+        and int(dist_artifacts.get("files_verified") or 0) > 0
+        and bool(dist_artifacts.get("signature_verified"))
+        and not str(dist_artifacts.get("skipped_reason") or "").strip()
+        and str(supported_api_smoke.get("status") or "") == "passed"
+        and str(optional_runtime_smoke.get("status") or "") == "passed"
+        and str(installed_runtime_smoke.get("status") or "") == "passed"
+    )
+    return {
+        "present": True,
+        "status": "complete" if complete else "incomplete",
+        "dist_files_verified": int(dist_artifacts.get("files_verified") or 0),
+        "dist_signature_verified": bool(dist_artifacts.get("signature_verified")),
+        "dist_skipped_reason": str(dist_artifacts.get("skipped_reason") or ""),
+        "supported_api_smoke_status": str(supported_api_smoke.get("status") or ""),
+        "optional_runtime_smoke_status": str(optional_runtime_smoke.get("status") or ""),
+        "installed_runtime_smoke_status": str(installed_runtime_smoke.get("status") or ""),
+    }
+
+
+def _existing_path(path: Path | None) -> bool:
+    return path is not None and path.exists()
+
+
+def _build_operator_workflow_requirements() -> list[dict[str, str]]:
+    return [
+        {
+            "surface": "/v1/search",
+            "requirement": "Provide a deployed-host, text-index-enabled Fuseki workflow in the supported Windows single-host operator path before promotion.",
+            "source": "docs/capability_graduation_boundaries.md#1-text-search",
+        },
+        {
+            "surface": "KG expansion",
+            "requirement": "Keep KG expansion default-off until release-gated smoke covers the configured success path and the declared failure policy.",
+            "source": "docs/capability_graduation_boundaries.md#3-kg-expansion",
+        },
+        {
+            "surface": "Deployed host baseline",
+            "requirement": "Do not enable EARCRAWLER_API_ENABLE_SEARCH or EARCRAWLER_ENABLE_KG_EXPANSION on deployed hosts before the quarantine gate passes.",
+            "source": "docs/ops/windows_single_host_operator.md",
+        },
+        {
+            "surface": "Release evidence",
+            "requirement": "Archive supported API smoke, optional runtime smoke, installed runtime smoke, and release validation evidence together for the review package.",
+            "source": "docs/ops/release_process.md",
+        },
+    ]
+
+
+def _build_rollback_requirements() -> list[dict[str, str]]:
+    return [
+        {
+            "surface": "/v1/search",
+            "rollback": "Disable EARCRAWLER_API_ENABLE_SEARCH, restart the service, and return to API contract artifacts that exclude /v1/search.",
+            "source": "docs/capability_graduation_boundaries.md#1-text-search",
+        },
+        {
+            "surface": "KG expansion",
+            "rollback": "Disable EARCRAWLER_ENABLE_KG_EXPANSION and return to retrieval-only RAG behavior.",
+            "source": "docs/capability_graduation_boundaries.md#3-kg-expansion",
+        },
+        {
+            "surface": "Optional/quarantined validation modes",
+            "rollback": "Reset search and KG env vars to 0 and restart the EarCrawler API service.",
+            "source": "docs/ops/windows_single_host_operator.md",
+        },
+    ]
+
+
+def _build_failure_mode_expectations(optional_smoke: Mapping[str, Any] | None) -> list[dict[str, Any]]:
+    kg_checks = {}
+    if optional_smoke and isinstance(optional_smoke.get("kg_expansion_failure_policy_checks"), Mapping):
+        kg_checks = dict(optional_smoke.get("kg_expansion_failure_policy_checks", {}).get("checks") or {})
+
+    search_statuses: dict[str, Any] = {}
+    if optional_smoke and isinstance(optional_smoke.get("search_mode_checks"), list):
+        for item in optional_smoke.get("search_mode_checks") or []:
+            if isinstance(item, Mapping):
+                search_statuses[str(item.get("name") or "")] = item
+
+    return [
+        {
+            "surface": "/v1/search default-off",
+            "expected_behavior": "The route should return 404 when the search gate is disabled.",
+            "source": "scripts/optional-runtime-smoke.ps1",
+            "current_observation": (
+                search_statuses.get("search_default_off", {}).get("search", {}).get("status_code")
+                if search_statuses.get("search_default_off")
+                else None
+            ),
+        },
+        {
+            "surface": "/v1/search opt-in",
+            "expected_behavior": "The route should return 200 only when EARCRAWLER_API_ENABLE_SEARCH=1 is set for local validation.",
+            "source": "scripts/optional-runtime-smoke.ps1",
+            "current_observation": (
+                search_statuses.get("search_opt_in_on", {}).get("search", {}).get("status_code")
+                if search_statuses.get("search_opt_in_on")
+                else None
+            ),
+        },
+        {
+            "surface": "KG expansion failure_policy=disable",
+            "expected_behavior": "Missing Fuseki should fail closed to no expansion rows rather than silently widening support claims.",
+            "source": "docs/kg_quarantine_exit_gate.md#6-failure-behavior-is-defined-and-conservative",
+            "current_observation": kg_checks.get("disable_missing_fuseki"),
+        },
+        {
+            "surface": "KG expansion failure_policy=error",
+            "expected_behavior": "Missing Fuseki should raise a bounded runtime error when failure_policy=error is selected.",
+            "source": "docs/kg_quarantine_exit_gate.md#6-failure-behavior-is-defined-and-conservative",
+            "current_observation": kg_checks.get("error_missing_fuseki"),
+        },
+    ]
+
+
+def _build_gap_list(
+    *,
+    optional_summary: Mapping[str, Any],
+    installed_summary: Mapping[str, Any],
+    release_summary: Mapping[str, Any],
+    search_prod_smoke: Path | None,
+    search_operator_evidence: Path | None,
+    kg_prod_smoke: Path | None,
+) -> list[str]:
+    gaps: list[str] = []
+    if str(optional_summary.get("status")) != "passed":
+        gaps.append("Optional runtime smoke does not fully prove the required search/KG gate checks in the current workspace.")
+    if str(installed_summary.get("status")) != "passed":
+        gaps.append("Installed runtime smoke does not currently prove the quarantined search/KG contract in release shape.")
+    if str(release_summary.get("status")) != "complete":
+        reason = str(release_summary.get("dist_skipped_reason") or "").strip()
+        if reason:
+            gaps.append(f"Release validation evidence is incomplete: {reason}.")
+        else:
+            gaps.append("Release validation evidence is incomplete for the required smoke and distributable-artifact checks.")
+    if not _existing_path(search_operator_evidence):
+        gaps.append("No operator-owned text-index-enabled Fuseki provisioning/rollback evidence is attached for /v1/search.")
+    if not _existing_path(search_prod_smoke):
+        gaps.append("No production-like smoke artifact is attached for /v1/search against a real text-index-backed Fuseki runtime path.")
+    if not _existing_path(kg_prod_smoke):
+        gaps.append("No production-like smoke artifact is attached for KG expansion success through the supported runtime shape.")
+    return gaps
+
+
+def _render_markdown(payload: Mapping[str, Any]) -> str:
+    lines = [
+        "# Search/KG Evidence Bundle",
+        "",
+        f"Decision date: {payload['decision_date']}",
+        "",
+        f"Recommendation: **{payload['recommendation']}**",
+        "",
+        "## Capability snapshot",
+        "",
+    ]
+    for capability in payload["capability_snapshot"]:
+        lines.extend(
+            [
+                f"- `{capability['id']}`: `{capability['status']}`",
+                f"  - Surfaces: {', '.join(capability['surfaces'])}",
+                f"  - Gate: {', '.join(capability['gates']) if capability['gates'] else 'none'}",
+            ]
+        )
+
+    lines.extend(
+        [
+            "",
+            "## Required smoke coverage",
+            "",
+            f"- Optional runtime smoke: `{payload['required_smoke_coverage']['optional_runtime_smoke']['status']}`",
+            f"- Installed runtime smoke: `{payload['required_smoke_coverage']['installed_runtime_smoke']['status']}`",
+            f"- Release validation evidence: `{payload['required_smoke_coverage']['release_validation']['status']}`",
+            "",
+            "## Blocking gaps",
+            "",
+        ]
+    )
+    for gap in payload["blocking_gaps"]:
+        lines.append(f"- {gap}")
+
+    lines.extend(
+        [
+            "",
+            "## Governing docs",
+            "",
+        ]
+    )
+    for doc in payload["governing_docs"]:
+        lines.append(f"- `{doc}`")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Build a dated search/KG evidence bundle and go/no-go recommendation."
+    )
+    parser.add_argument("--capability-registry", type=Path, default=DEFAULT_CAPABILITY_REGISTRY)
+    parser.add_argument("--optional-runtime-smoke", type=Path, default=DEFAULT_OPTIONAL_RUNTIME_SMOKE)
+    parser.add_argument("--installed-runtime-smoke", type=Path, default=DEFAULT_INSTALLED_RUNTIME_SMOKE)
+    parser.add_argument("--release-validation-evidence", type=Path, default=DEFAULT_RELEASE_EVIDENCE)
+    parser.add_argument("--search-prod-smoke", type=Path, default=None)
+    parser.add_argument("--search-operator-evidence", type=Path, default=None)
+    parser.add_argument("--kg-prod-smoke", type=Path, default=None)
+    parser.add_argument("--decision-date", default=str(date.today()))
+    parser.add_argument("--out-json", type=Path, default=DEFAULT_OUT_JSON)
+    parser.add_argument("--out-md", type=Path, default=DEFAULT_OUT_MD)
+    args = parser.parse_args(argv)
+
+    registry = _read_json(args.capability_registry.resolve())
+    optional_runtime_smoke = (
+        _read_json(args.optional_runtime_smoke.resolve())
+        if args.optional_runtime_smoke.resolve().exists()
+        else None
+    )
+    installed_runtime_smoke = (
+        _read_json(args.installed_runtime_smoke.resolve())
+        if args.installed_runtime_smoke.resolve().exists()
+        else None
+    )
+    release_validation_evidence = (
+        _read_json(args.release_validation_evidence.resolve())
+        if args.release_validation_evidence.resolve().exists()
+        else None
+    )
+
+    search_capability = _lookup_capability(registry, "api.search")
+    kg_capability = _lookup_capability(registry, "kg.expansion")
+
+    optional_summary = _summarize_optional_runtime_smoke(optional_runtime_smoke)
+    installed_summary = _summarize_installed_runtime_smoke(installed_runtime_smoke)
+    release_summary = _summarize_release_evidence(release_validation_evidence)
+
+    gaps = _build_gap_list(
+        optional_summary=optional_summary,
+        installed_summary=installed_summary,
+        release_summary=release_summary,
+        search_prod_smoke=args.search_prod_smoke.resolve() if args.search_prod_smoke else None,
+        search_operator_evidence=args.search_operator_evidence.resolve() if args.search_operator_evidence else None,
+        kg_prod_smoke=args.kg_prod_smoke.resolve() if args.kg_prod_smoke else None,
+    )
+    recommendation = (
+        "Ready for formal promotion review" if not gaps else "Keep Quarantined"
+    )
+
+    payload = {
+        "schema_version": "search-kg-evidence-bundle.v1",
+        "created_at_utc": _utc_now_iso(),
+        "decision_date": args.decision_date,
+        "recommendation": recommendation,
+        "capability_snapshot": [
+            {
+                "id": "api.search",
+                "status": search_capability.get("status"),
+                "default_posture": search_capability.get("default_posture"),
+                "surfaces": search_capability.get("surfaces") or [],
+                "gates": search_capability.get("gates") or [],
+                "notes": search_capability.get("notes"),
+            },
+            {
+                "id": "kg.expansion",
+                "status": kg_capability.get("status"),
+                "default_posture": kg_capability.get("default_posture"),
+                "surfaces": kg_capability.get("surfaces") or [],
+                "gates": kg_capability.get("gates") or [],
+                "notes": kg_capability.get("notes"),
+            },
+        ],
+        "required_smoke_coverage": {
+            "optional_runtime_smoke": optional_summary,
+            "installed_runtime_smoke": installed_summary,
+            "release_validation": release_summary,
+        },
+        "operator_workflow_requirements": _build_operator_workflow_requirements(),
+        "rollback_requirements": _build_rollback_requirements(),
+        "failure_mode_expectations": _build_failure_mode_expectations(optional_runtime_smoke),
+        "blocking_gaps": gaps,
+        "evidence_inputs": {
+            "capability_registry": _rel(args.capability_registry.resolve()),
+            "optional_runtime_smoke": _rel(args.optional_runtime_smoke.resolve()),
+            "installed_runtime_smoke": _rel(args.installed_runtime_smoke.resolve()),
+            "release_validation_evidence": _rel(args.release_validation_evidence.resolve()),
+            "search_prod_smoke": _rel(args.search_prod_smoke.resolve()) if args.search_prod_smoke else None,
+            "search_operator_evidence": _rel(args.search_operator_evidence.resolve()) if args.search_operator_evidence else None,
+            "kg_prod_smoke": _rel(args.kg_prod_smoke.resolve()) if args.kg_prod_smoke else None,
+        },
+        "governing_docs": list(GOVERNING_DOCS),
+    }
+
+    _write_json(args.out_json.resolve(), payload)
+    _write_text(args.out_md.resolve(), _render_markdown(payload))
+    print(f"Wrote search/KG evidence bundle: {args.out_json.resolve()}")
+    print(f"Wrote search/KG evidence summary: {args.out_md.resolve()}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())
+

--- a/scripts/eval/validate_local_adapter_release_bundle.py
+++ b/scripts/eval/validate_local_adapter_release_bundle.py
@@ -1,0 +1,381 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_CONTRACT = REPO_ROOT / "config" / "local_adapter_release_evidence.example.json"
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _write_json(path: Path, payload: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _as_float(value: Any) -> float | None:
+    try:
+        if value is None:
+            return None
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _resolve_repo_path(raw: str) -> Path:
+    path = Path(str(raw))
+    if path.is_absolute():
+        return path.resolve()
+    return (REPO_ROOT / path).resolve()
+
+
+def _looks_sha256(value: str) -> bool:
+    return bool(re.fullmatch(r"[0-9a-f]{64}", str(value or "").strip().lower()))
+
+
+def _require_mapping(payload: Any, label: str) -> dict[str, Any]:
+    if not isinstance(payload, Mapping):
+        raise ValueError(f"{label} is not a JSON object.")
+    return dict(payload)
+
+
+def _check_threshold(
+    *,
+    name: str,
+    value: Any,
+    min_value: Any = None,
+    max_value: Any = None,
+    failures: list[str],
+) -> None:
+    numeric = _as_float(value)
+    if numeric is None:
+        failures.append(f"Missing numeric metric: {name}")
+        return
+    if min_value is not None and numeric < float(min_value):
+        failures.append(f"{name}={numeric:.4f} is below minimum {float(min_value):.4f}")
+    if max_value is not None and numeric > float(max_value):
+        failures.append(f"{name}={numeric:.4f} exceeds maximum {float(max_value):.4f}")
+
+
+def _collect_required_paths(root: Path, relatives: list[str]) -> tuple[dict[str, str], list[str]]:
+    resolved: dict[str, str] = {}
+    missing: list[str] = []
+    for rel in relatives:
+        path = (root / rel).resolve()
+        resolved[rel] = str(path)
+        if not path.exists():
+            missing.append(rel)
+    return resolved, missing
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Validate the minimum local-adapter release evidence bundle.")
+    parser.add_argument("--run-dir", type=Path, required=True, help="Task 5.3 run directory (dist/training/<run_id>).")
+    parser.add_argument("--benchmark-summary", type=Path, required=True, help="benchmark_summary.json from run_local_adapter_benchmark.py.")
+    parser.add_argument("--smoke-report", type=Path, default=Path("kg") / "reports" / "local-adapter-smoke.json")
+    parser.add_argument("--contract", type=Path, default=DEFAULT_CONTRACT)
+    parser.add_argument("--out", type=Path, default=None, help="Output path for release_evidence_manifest.json.")
+    args = parser.parse_args(argv)
+
+    run_dir = args.run_dir.resolve()
+    out_path = args.out.resolve() if args.out else (run_dir / "release_evidence_manifest.json").resolve()
+
+    try:
+        contract = _require_mapping(_read_json(args.contract.resolve()), "contract")
+    except Exception as exc:
+        print(f"Failed: cannot read contract: {exc}")
+        return 2
+
+    bundle_cfg = _require_mapping(contract.get("bundle"), "contract.bundle")
+    thresholds = _require_mapping(contract.get("thresholds"), "contract.thresholds")
+    comparisons = _require_mapping(contract.get("comparison_rules"), "contract.comparison_rules")
+    decision_rule = _require_mapping(contract.get("decision_rule"), "contract.decision_rule")
+
+    run_files = [str(item) for item in bundle_cfg.get("required_run_files") or []]
+    benchmark_files = [str(item) for item in bundle_cfg.get("required_benchmark_files") or []]
+    rollback_docs = [str(item) for item in bundle_cfg.get("rollback_docs") or []]
+    required_datasets = [str(item) for item in bundle_cfg.get("required_primary_datasets") or []]
+
+    run_paths, missing_run_files = _collect_required_paths(run_dir, run_files)
+
+    benchmark_summary_path = args.benchmark_summary.resolve()
+    benchmark_root = benchmark_summary_path.parent
+    benchmark_paths, missing_benchmark_files = _collect_required_paths(benchmark_root, benchmark_files)
+    rollback_path_map = {doc: str(_resolve_repo_path(doc)) for doc in rollback_docs}
+    missing_rollback_docs = [doc for doc, path in rollback_path_map.items() if not Path(path).exists()]
+
+    failures: list[str] = []
+    insufficient: list[str] = []
+    if missing_run_files:
+        insufficient.append("Missing required run artifacts: " + ", ".join(sorted(missing_run_files)))
+    if missing_benchmark_files:
+        insufficient.append("Missing required benchmark artifacts: " + ", ".join(sorted(missing_benchmark_files)))
+    if missing_rollback_docs:
+        insufficient.append("Missing rollback docs: " + ", ".join(sorted(missing_rollback_docs)))
+
+    manifest: dict[str, Any] = {}
+    run_metadata: dict[str, Any] = {}
+    inference_smoke: dict[str, Any] = {}
+    runtime_smoke: dict[str, Any] = {}
+    benchmark_summary: dict[str, Any] = {}
+    benchmark_manifest: dict[str, Any] = {}
+
+    parse_failures: list[str] = []
+    try:
+        manifest = _require_mapping(_read_json(run_dir / "manifest.json"), "manifest.json")
+    except Exception as exc:
+        parse_failures.append(f"Cannot read manifest.json: {exc}")
+    try:
+        run_metadata = _require_mapping(_read_json(run_dir / "run_metadata.json"), "run_metadata.json")
+    except Exception as exc:
+        parse_failures.append(f"Cannot read run_metadata.json: {exc}")
+    try:
+        inference_smoke = _require_mapping(_read_json(run_dir / "inference_smoke.json"), "inference_smoke.json")
+    except Exception as exc:
+        parse_failures.append(f"Cannot read inference_smoke.json: {exc}")
+    try:
+        runtime_smoke = _require_mapping(_read_json(args.smoke_report.resolve()), "local-adapter-smoke.json")
+    except Exception as exc:
+        parse_failures.append(f"Cannot read smoke report: {exc}")
+    try:
+        benchmark_summary = _require_mapping(_read_json(benchmark_summary_path), "benchmark_summary.json")
+    except Exception as exc:
+        parse_failures.append(f"Cannot read benchmark_summary.json: {exc}")
+    try:
+        benchmark_manifest = _require_mapping(_read_json(benchmark_root / "benchmark_manifest.json"), "benchmark_manifest.json")
+    except Exception as exc:
+        parse_failures.append(f"Cannot read benchmark_manifest.json: {exc}")
+    if parse_failures:
+        insufficient.extend(parse_failures)
+
+    manifest_checks: list[str] = []
+    if manifest:
+        if str(manifest.get("manifest_version") or "").strip() != "training-package.v1":
+            manifest_checks.append("manifest.json manifest_version must equal training-package.v1")
+        if not str(manifest.get("snapshot_id") or "").strip():
+            manifest_checks.append("manifest.json is missing snapshot_id")
+        if not _looks_sha256(str(manifest.get("snapshot_sha256") or "")):
+            manifest_checks.append("manifest.json is missing a valid snapshot_sha256")
+        if not _looks_sha256(str(manifest.get("retrieval_corpus_digest") or "")):
+            manifest_checks.append("manifest.json is missing a valid retrieval_corpus_digest")
+        if int(manifest.get("retrieval_corpus_doc_count") or 0) <= 0:
+            manifest_checks.append("manifest.json retrieval_corpus_doc_count must be positive")
+        if not str(manifest.get("training_input_contract_path") or "").strip():
+            manifest_checks.append("manifest.json is missing training_input_contract_path")
+    if manifest_checks:
+        insufficient.extend(manifest_checks)
+
+    metadata_checks: list[str] = []
+    if run_metadata:
+        if str(run_metadata.get("schema_version") or "").strip() != "training-run-metadata.v1":
+            metadata_checks.append("run_metadata.json schema_version must equal training-run-metadata.v1")
+        if str(run_metadata.get("status") or "").strip() != "completed":
+            metadata_checks.append("run_metadata.json status must equal completed")
+    if metadata_checks:
+        insufficient.extend(metadata_checks)
+
+    inference_checks: list[str] = []
+    if inference_smoke:
+        if not bool(inference_smoke.get("pass")):
+            inference_checks.append("inference_smoke.json must record pass=true")
+        if str(inference_smoke.get("base_model") or "").strip() != str(manifest.get("base_model") or "").strip():
+            inference_checks.append("inference_smoke.json base_model must match manifest.json")
+    if inference_checks:
+        insufficient.extend(inference_checks)
+
+    runtime_checks: list[str] = []
+    if runtime_smoke:
+        if str(runtime_smoke.get("status") or "").strip().lower() != "passed":
+            runtime_checks.append("local-adapter-smoke.json must record status=passed")
+        if str(runtime_smoke.get("provider") or "").strip().lower() != "local_adapter":
+            runtime_checks.append("local-adapter-smoke.json provider must equal local_adapter")
+        smoke_run_dir = str(runtime_smoke.get("run_dir") or "").strip()
+        if smoke_run_dir and Path(smoke_run_dir).resolve() != run_dir:
+            runtime_checks.append("local-adapter-smoke.json run_dir does not match the candidate run_dir")
+    if runtime_checks:
+        insufficient.extend(runtime_checks)
+
+    benchmark_checks: list[str] = []
+    if benchmark_summary:
+        if str(benchmark_summary.get("schema_version") or "").strip() != "local-adapter-benchmark.v1":
+            benchmark_checks.append("benchmark_summary.json schema_version must equal local-adapter-benchmark.v1")
+        dataset_ids = {str(item) for item in benchmark_summary.get("dataset_ids") or []}
+        missing_datasets = sorted(set(required_datasets) - dataset_ids)
+        if missing_datasets:
+            benchmark_checks.append("benchmark_summary.json is missing required datasets: " + ", ".join(missing_datasets))
+        try:
+            summary_run = _require_mapping(benchmark_summary.get("training_run"), "benchmark_summary.training_run")
+            summary_run_dir = str(summary_run.get("run_dir") or "").strip()
+            if summary_run_dir and Path(summary_run_dir).resolve() != run_dir:
+                benchmark_checks.append("benchmark_summary.json training_run.run_dir does not match the candidate run_dir")
+        except Exception as exc:
+            benchmark_checks.append(str(exc))
+        try:
+            smoke_precondition = _require_mapping(benchmark_summary.get("smoke_precondition"), "benchmark_summary.smoke_precondition")
+            if str(smoke_precondition.get("status") or "").strip().lower() != "passed":
+                benchmark_checks.append("benchmark_summary.json smoke_precondition.status must equal passed")
+        except Exception as exc:
+            benchmark_checks.append(str(exc))
+    if benchmark_manifest:
+        try:
+            manifest_run = _require_mapping(benchmark_manifest.get("training_run"), "benchmark_manifest.training_run")
+            manifest_run_dir = str(manifest_run.get("run_dir") or "").strip()
+            if manifest_run_dir and Path(manifest_run_dir).resolve() != run_dir:
+                benchmark_checks.append("benchmark_manifest.json training_run.run_dir does not match the candidate run_dir")
+        except Exception as exc:
+            benchmark_checks.append(str(exc))
+    if benchmark_checks:
+        insufficient.extend(benchmark_checks)
+
+    local_metrics: dict[str, Any] = {}
+    retrieval_metrics: dict[str, Any] = {}
+    if benchmark_summary:
+        conditions = benchmark_summary.get("conditions") or {}
+        if isinstance(conditions, Mapping):
+            local_raw = conditions.get("local_adapter")
+            if isinstance(local_raw, Mapping):
+                local_metrics = dict(local_raw)
+            else:
+                insufficient.append("benchmark_summary.json is missing conditions.local_adapter")
+            if comparisons.get("require_retrieval_only_condition"):
+                retrieval_raw = conditions.get("retrieval_only")
+                if isinstance(retrieval_raw, Mapping):
+                    retrieval_metrics = dict(retrieval_raw)
+                else:
+                    insufficient.append("benchmark_summary.json is missing conditions.retrieval_only")
+        else:
+            insufficient.append("benchmark_summary.json is missing conditions")
+
+    if local_metrics:
+        _check_threshold(name="local_adapter.answer_accuracy", value=local_metrics.get("answer_accuracy"), min_value=thresholds.get("answer_accuracy_min"), failures=failures)
+        _check_threshold(name="local_adapter.label_accuracy", value=local_metrics.get("label_accuracy"), min_value=thresholds.get("label_accuracy_min"), failures=failures)
+        _check_threshold(name="local_adapter.unanswerable_accuracy", value=local_metrics.get("unanswerable_accuracy"), min_value=thresholds.get("unanswerable_accuracy_min"), failures=failures)
+        _check_threshold(name="local_adapter.valid_citation_rate", value=local_metrics.get("valid_citation_rate"), min_value=thresholds.get("valid_citation_rate_min"), failures=failures)
+        _check_threshold(name="local_adapter.supported_rate", value=local_metrics.get("supported_rate"), min_value=thresholds.get("supported_rate_min"), failures=failures)
+        _check_threshold(name="local_adapter.overclaim_rate", value=local_metrics.get("overclaim_rate"), max_value=thresholds.get("overclaim_rate_max"), failures=failures)
+        _check_threshold(name="local_adapter.strict_output_failure_rate", value=local_metrics.get("strict_output_failure_rate"), max_value=thresholds.get("strict_output_failure_rate_max"), failures=failures)
+        _check_threshold(name="local_adapter.request_422_rate", value=local_metrics.get("request_422_rate"), max_value=thresholds.get("request_422_rate_max"), failures=failures)
+        _check_threshold(name="local_adapter.request_503_rate", value=local_metrics.get("request_503_rate"), max_value=thresholds.get("request_503_rate_max"), failures=failures)
+        lat_raw = local_metrics.get("latency_ms")
+        if isinstance(lat_raw, Mapping):
+            lat = dict(lat_raw)
+            _check_threshold(name="local_adapter.latency_ms.p95", value=lat.get("p95"), max_value=thresholds.get("latency_p95_ms_max"), failures=failures)
+        else:
+            failures.append("Missing numeric metric: local_adapter.latency_ms.p95")
+
+    comparison_failures: list[str] = []
+    if local_metrics and retrieval_metrics:
+        local_answer = _as_float(local_metrics.get("answer_accuracy"))
+        retrieval_answer = _as_float(retrieval_metrics.get("answer_accuracy"))
+        if comparisons.get("answer_accuracy_gte_retrieval_only") and local_answer is not None and retrieval_answer is not None and local_answer < retrieval_answer:
+            comparison_failures.append("local_adapter.answer_accuracy is below retrieval_only.answer_accuracy")
+        local_supported = _as_float(local_metrics.get("supported_rate"))
+        retrieval_supported = _as_float(retrieval_metrics.get("supported_rate"))
+        if comparisons.get("supported_rate_gte_retrieval_only") and local_supported is not None and retrieval_supported is not None and local_supported < retrieval_supported:
+            comparison_failures.append("local_adapter.supported_rate is below retrieval_only.supported_rate")
+        local_overclaim = _as_float(local_metrics.get("overclaim_rate"))
+        retrieval_overclaim = _as_float(retrieval_metrics.get("overclaim_rate"))
+        if comparisons.get("overclaim_rate_lte_retrieval_only") and local_overclaim is not None and retrieval_overclaim is not None and local_overclaim > retrieval_overclaim:
+            comparison_failures.append("local_adapter.overclaim_rate exceeds retrieval_only.overclaim_rate")
+
+    all_failures = insufficient + failures + comparison_failures
+    decision = "ready_for_formal_promotion_review" if not all_failures else "keep_optional"
+    evidence_status = "complete" if not all_failures else "insufficient"
+
+    payload = {
+        "schema_version": "local-adapter-release-evidence.v1",
+        "created_at_utc": _utc_now_iso(),
+        "contract_path": str(args.contract.resolve()),
+        "capability_id": str(contract.get("capability_id") or ""),
+        "training_run": {
+            "run_dir": str(run_dir),
+            "manifest_path": str((run_dir / "manifest.json").resolve()),
+            "run_config_path": str((run_dir / "run_config.json").resolve()),
+            "run_metadata_path": str((run_dir / "run_metadata.json").resolve()),
+            "inference_smoke_path": str((run_dir / "inference_smoke.json").resolve()),
+            "adapter_dir": str((run_dir / "adapter").resolve()),
+            "snapshot_id": manifest.get("snapshot_id"),
+            "snapshot_sha256": manifest.get("snapshot_sha256"),
+            "retrieval_corpus_path": manifest.get("retrieval_corpus_path"),
+            "retrieval_corpus_digest": manifest.get("retrieval_corpus_digest"),
+            "retrieval_corpus_doc_count": manifest.get("retrieval_corpus_doc_count"),
+            "base_model": manifest.get("base_model"),
+            "git_head": run_metadata.get("git_head"),
+            "file_hashes": {
+                rel: _sha256_file(Path(path)) for rel, path in run_paths.items() if Path(path).exists()
+            }
+        },
+        "runtime_smoke": {
+            "path": str(args.smoke_report.resolve()),
+            "sha256": _sha256_file(args.smoke_report.resolve()) if args.smoke_report.resolve().exists() else None,
+            "status": runtime_smoke.get("status"),
+            "provider": runtime_smoke.get("provider"),
+            "endpoint": runtime_smoke.get("endpoint"),
+            "trace_id": runtime_smoke.get("trace_id")
+        },
+        "benchmark": {
+            "root": str(benchmark_root),
+            "summary_path": str(benchmark_summary_path),
+            "summary_sha256": _sha256_file(benchmark_summary_path) if benchmark_summary_path.exists() else None,
+            "manifest_path": str((benchmark_root / "benchmark_manifest.json").resolve()),
+            "artifact_hashes": {
+                rel: _sha256_file(Path(path)) for rel, path in benchmark_paths.items() if Path(path).exists()
+            },
+            "dataset_ids": benchmark_summary.get("dataset_ids") or [],
+            "conditions": benchmark_summary.get("conditions") or {}
+        },
+        "rollback_docs": {
+            "required": rollback_docs,
+            "resolved": rollback_path_map
+        },
+        "checks": {
+            "missing_run_files": sorted(missing_run_files),
+            "missing_benchmark_files": sorted(missing_benchmark_files),
+            "missing_rollback_docs": sorted(missing_rollback_docs),
+            "manifest_checks": manifest_checks,
+            "run_metadata_checks": metadata_checks,
+            "inference_smoke_checks": inference_checks,
+            "runtime_smoke_checks": runtime_checks,
+            "benchmark_checks": benchmark_checks,
+            "threshold_failures": failures,
+            "comparison_failures": comparison_failures
+        },
+        "thresholds": thresholds,
+        "decision_rule": decision_rule,
+        "evidence_status": evidence_status,
+        "decision": decision,
+        "insufficient_evidence": all_failures
+    }
+    _write_json(out_path, payload)
+
+    if decision == "ready_for_formal_promotion_review":
+        print(f"Wrote passing release evidence manifest: {out_path}")
+        return 0
+
+    print(f"Release evidence is insufficient. Wrote manifest: {out_path}")
+    return 1
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/scripts/training/run_phase5_finetune.py
+++ b/scripts/training/run_phase5_finetune.py
@@ -651,6 +651,8 @@ def _run_inference_smoke(
     )
     passed = bool(completion)
     return {
+        "base_model": base_model,
+        "adapter_dir": str(adapter_dir),
         "prompt": prompt,
         "generated_text": decoded,
         "completion": completion,

--- a/tests/eval/test_local_adapter_release_bundle_validator.py
+++ b/tests/eval/test_local_adapter_release_bundle_validator.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts.eval import validate_local_adapter_release_bundle as validator
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _make_run_dir(tmp_path: Path) -> Path:
+    run_dir = tmp_path / "training" / "run-1"
+    adapter = run_dir / "adapter"
+    adapter.mkdir(parents=True)
+    _write_json(
+        run_dir / "manifest.json",
+        {
+            "manifest_version": "training-package.v1",
+            "run_id": "run-1",
+            "base_model": "Qwen/Qwen2.5-7B-Instruct",
+            "snapshot_id": "ecfr-title15-2026-02-28",
+            "snapshot_sha256": "a" * 64,
+            "retrieval_corpus_path": "data/faiss/retrieval_corpus.jsonl",
+            "retrieval_corpus_digest": "b" * 64,
+            "retrieval_corpus_doc_count": 3040,
+            "training_input_contract_path": "config/training_input_contract.example.json",
+            "index_meta_path": "data/faiss/index.meta.json",
+        },
+    )
+    _write_json(
+        run_dir / "run_config.json",
+        {
+            "schema_version": "training-run-config.v1",
+            "run_id": "run-1",
+        },
+    )
+    _write_json(
+        run_dir / "run_metadata.json",
+        {
+            "schema_version": "training-run-metadata.v1",
+            "run_id": "run-1",
+            "status": "completed",
+            "git_head": "deadbeef",
+        },
+    )
+    _write_json(
+        run_dir / "inference_smoke.json",
+        {
+            "pass": True,
+            "base_model": "Qwen/Qwen2.5-7B-Instruct",
+        },
+    )
+    _write_json(adapter / "adapter_config.json", {})
+    _write_json(adapter / "tokenizer_config.json", {})
+    return run_dir
+
+
+def _make_benchmark_bundle(
+    tmp_path: Path,
+    run_dir: Path,
+    *,
+    answer_accuracy: float = 0.82,
+) -> Path:
+    bench_dir = tmp_path / "benchmarks" / "bundle-1"
+    bench_dir.mkdir(parents=True, exist_ok=True)
+    _write_json(
+        bench_dir / "benchmark_manifest.json",
+        {
+            "manifest_version": "local-adapter-benchmark.v1",
+            "training_run": {"run_dir": str(run_dir)},
+        },
+    )
+    summary = {
+        "schema_version": "local-adapter-benchmark.v1",
+        "dataset_ids": [
+            "ear_compliance.v2",
+            "entity_obligations.v2",
+            "unanswerable.v2",
+        ],
+        "training_run": {"run_dir": str(run_dir)},
+        "smoke_precondition": {"status": "passed"},
+        "conditions": {
+            "local_adapter": {
+                "answer_accuracy": answer_accuracy,
+                "label_accuracy": 0.9,
+                "unanswerable_accuracy": 1.0,
+                "valid_citation_rate": 0.98,
+                "supported_rate": 0.94,
+                "overclaim_rate": 0.01,
+                "strict_output_failure_rate": 0.0,
+                "request_422_rate": 0.0,
+                "request_503_rate": 0.0,
+                "latency_ms": {"p95": 1200},
+            },
+            "retrieval_only": {
+                "answer_accuracy": 0.6,
+                "label_accuracy": 0.7,
+                "unanswerable_accuracy": 0.9,
+                "valid_citation_rate": 0.96,
+                "supported_rate": 0.8,
+                "overclaim_rate": 0.03,
+                "strict_output_failure_rate": 0.0,
+                "request_422_rate": 0.0,
+                "request_503_rate": 0.0,
+                "latency_ms": {"p95": 200},
+            },
+        },
+    }
+    _write_json(bench_dir / "benchmark_summary.json", summary)
+    (bench_dir / "benchmark_summary.md").write_text("# summary\n", encoding="utf-8")
+    _write_json(bench_dir / "benchmark_artifacts.json", {"conditions": {}})
+    return bench_dir / "benchmark_summary.json"
+
+
+def _make_smoke_report(tmp_path: Path, run_dir: Path) -> Path:
+    smoke_report = tmp_path / "kg" / "reports" / "local-adapter-smoke.json"
+    _write_json(
+        smoke_report,
+        {
+            "status": "passed",
+            "run_dir": str(run_dir),
+            "provider": "local_adapter",
+            "endpoint": "http://127.0.0.1:9001/v1/rag/answer",
+            "trace_id": "t-1",
+        },
+    )
+    return smoke_report
+
+
+def test_validator_writes_release_evidence_manifest_for_passing_bundle(
+    tmp_path: Path,
+) -> None:
+    run_dir = _make_run_dir(tmp_path)
+    benchmark_summary = _make_benchmark_bundle(tmp_path, run_dir)
+    smoke_report = _make_smoke_report(tmp_path, run_dir)
+
+    out_path = run_dir / "release_evidence_manifest.json"
+    rc = validator.main(
+        [
+            "--run-dir",
+            str(run_dir),
+            "--benchmark-summary",
+            str(benchmark_summary),
+            "--smoke-report",
+            str(smoke_report),
+            "--out",
+            str(out_path),
+        ]
+    )
+
+    assert rc == 0
+    payload = json.loads(out_path.read_text(encoding="utf-8"))
+    assert payload["schema_version"] == "local-adapter-release-evidence.v1"
+    assert payload["decision"] == "ready_for_formal_promotion_review"
+    assert payload["evidence_status"] == "complete"
+    assert payload["training_run"]["retrieval_corpus_digest"] == "b" * 64
+
+
+def test_validator_keeps_capability_optional_when_thresholds_fail(
+    tmp_path: Path,
+) -> None:
+    run_dir = _make_run_dir(tmp_path)
+    benchmark_summary = _make_benchmark_bundle(
+        tmp_path, run_dir, answer_accuracy=0.4
+    )
+    smoke_report = _make_smoke_report(tmp_path, run_dir)
+
+    out_path = run_dir / "release_evidence_manifest.json"
+    rc = validator.main(
+        [
+            "--run-dir",
+            str(run_dir),
+            "--benchmark-summary",
+            str(benchmark_summary),
+            "--smoke-report",
+            str(smoke_report),
+            "--out",
+            str(out_path),
+        ]
+    )
+
+    assert rc == 1
+    payload = json.loads(out_path.read_text(encoding="utf-8"))
+    assert payload["decision"] == "keep_optional"
+    assert payload["evidence_status"] == "insufficient"
+    assert any(
+        "local_adapter.answer_accuracy" in item
+        for item in payload["insufficient_evidence"]
+    )

--- a/tests/eval/test_search_kg_evidence_bundle.py
+++ b/tests/eval/test_search_kg_evidence_bundle.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts.eval import build_search_kg_evidence_bundle as bundle
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _make_registry(tmp_path: Path) -> Path:
+    registry_path = tmp_path / "service" / "docs" / "capability_registry.json"
+    _write_json(
+        registry_path,
+        {
+            "schema_version": "capability-registry.v1",
+            "capabilities": [
+                {
+                    "id": "api.search",
+                    "status": "quarantined",
+                    "default_posture": "disabled",
+                    "surfaces": ["/v1/search"],
+                    "gates": ["EARCRAWLER_API_ENABLE_SEARCH=1"],
+                    "notes": "Quarantined search route.",
+                },
+                {
+                    "id": "kg.expansion",
+                    "status": "quarantined",
+                    "default_posture": "disabled",
+                    "surfaces": ["EARCRAWLER_ENABLE_KG_EXPANSION=1"],
+                    "gates": ["EARCRAWLER_ENABLE_KG_EXPANSION=1"],
+                    "notes": "Quarantined KG expansion.",
+                },
+            ],
+        },
+    )
+    return registry_path
+
+
+def _make_optional_runtime_smoke(tmp_path: Path) -> Path:
+    path = tmp_path / "dist" / "optional_runtime_smoke.json"
+    _write_json(
+        path,
+        {
+            "schema_version": "optional-runtime-smoke.v1",
+            "overall_status": "passed",
+            "search_mode_checks": [
+                {"name": "search_default_off", "status": "passed", "search": {"status_code": 404}},
+                {"name": "search_opt_in_on", "status": "passed", "search": {"status_code": 200}},
+                {"name": "search_rollback_off", "status": "passed", "search": {"status_code": 404}},
+            ],
+            "kg_expansion_failure_policy_checks": {
+                "status": "passed",
+                "checks": {
+                    "disable_missing_fuseki": {"status": "passed"},
+                    "error_missing_fuseki": {"status": "passed"},
+                    "json_stub_expansion": {"status": "passed"},
+                },
+            },
+        },
+    )
+    return path
+
+
+def _make_installed_runtime_smoke(tmp_path: Path) -> Path:
+    path = tmp_path / "dist" / "installed_runtime_smoke.json"
+    _write_json(
+        path,
+        {
+            "schema_version": "installed-runtime-smoke.v1",
+            "overall_status": "passed",
+            "checks": [
+                {"name": "runtime_contract_api_search", "passed": True},
+                {"name": "runtime_contract_kg_expansion", "passed": True},
+            ],
+        },
+    )
+    return path
+
+
+def _make_release_validation_evidence(tmp_path: Path, *, complete: bool) -> Path:
+    path = tmp_path / "dist" / "release_validation_evidence.json"
+    _write_json(
+        path,
+        {
+            "schema_version": "release-validation-evidence.v1",
+            "dist_artifacts": {
+                "files_verified": 1 if complete else 0,
+                "signature_verified": complete,
+                "skipped_reason": "" if complete else "checksums file not found",
+            },
+            "supported_api_smoke": {"status": "passed"},
+            "optional_runtime_smoke": {"status": "passed"},
+            "installed_runtime_smoke": {"status": "passed"},
+        },
+    )
+    return path
+
+
+def test_bundle_keeps_search_and_kg_quarantined_when_gate_evidence_is_incomplete(
+    tmp_path: Path,
+) -> None:
+    registry = _make_registry(tmp_path)
+    optional_smoke = _make_optional_runtime_smoke(tmp_path)
+    installed_smoke = _make_installed_runtime_smoke(tmp_path)
+    release_evidence = _make_release_validation_evidence(tmp_path, complete=False)
+    out_json = tmp_path / "out" / "bundle.json"
+    out_md = tmp_path / "out" / "bundle.md"
+
+    rc = bundle.main(
+        [
+            "--capability-registry",
+            str(registry),
+            "--optional-runtime-smoke",
+            str(optional_smoke),
+            "--installed-runtime-smoke",
+            str(installed_smoke),
+            "--release-validation-evidence",
+            str(release_evidence),
+            "--decision-date",
+            "2026-03-19",
+            "--out-json",
+            str(out_json),
+            "--out-md",
+            str(out_md),
+        ]
+    )
+
+    assert rc == 0
+    payload = json.loads(out_json.read_text(encoding="utf-8"))
+    assert payload["schema_version"] == "search-kg-evidence-bundle.v1"
+    assert payload["recommendation"] == "Keep Quarantined"
+    assert payload["required_smoke_coverage"]["optional_runtime_smoke"]["status"] == "passed"
+    assert payload["required_smoke_coverage"]["installed_runtime_smoke"]["status"] == "passed"
+    assert payload["required_smoke_coverage"]["release_validation"]["status"] == "incomplete"
+    assert any("text-index-enabled Fuseki" in item for item in payload["blocking_gaps"])
+    assert "Keep Quarantined" in out_md.read_text(encoding="utf-8")
+
+
+
+def test_bundle_marks_ready_for_formal_promotion_review_only_with_complete_evidence(
+    tmp_path: Path,
+) -> None:
+    registry = _make_registry(tmp_path)
+    optional_smoke = _make_optional_runtime_smoke(tmp_path)
+    installed_smoke = _make_installed_runtime_smoke(tmp_path)
+    release_evidence = _make_release_validation_evidence(tmp_path, complete=True)
+    search_prod_smoke = tmp_path / "evidence" / "search_prod_smoke.json"
+    search_operator = tmp_path / "evidence" / "search_operator_evidence.md"
+    kg_prod_smoke = tmp_path / "evidence" / "kg_prod_smoke.json"
+    search_prod_smoke.parent.mkdir(parents=True, exist_ok=True)
+    search_prod_smoke.write_text("{}", encoding="utf-8")
+    search_operator.write_text("# operator proof\n", encoding="utf-8")
+    kg_prod_smoke.write_text("{}", encoding="utf-8")
+    out_json = tmp_path / "out" / "bundle.json"
+    out_md = tmp_path / "out" / "bundle.md"
+
+    rc = bundle.main(
+        [
+            "--capability-registry",
+            str(registry),
+            "--optional-runtime-smoke",
+            str(optional_smoke),
+            "--installed-runtime-smoke",
+            str(installed_smoke),
+            "--release-validation-evidence",
+            str(release_evidence),
+            "--search-prod-smoke",
+            str(search_prod_smoke),
+            "--search-operator-evidence",
+            str(search_operator),
+            "--kg-prod-smoke",
+            str(kg_prod_smoke),
+            "--decision-date",
+            "2026-03-19",
+            "--out-json",
+            str(out_json),
+            "--out-md",
+            str(out_md),
+        ]
+    )
+
+    assert rc == 0
+    payload = json.loads(out_json.read_text(encoding="utf-8"))
+    assert payload["recommendation"] == "Ready for formal promotion review"
+    assert payload["blocking_gaps"] == []
+    assert "Ready for formal promotion review" in out_md.read_text(encoding="utf-8")

--- a/tests/tooling/test_phase5_inference_smoke_metadata.py
+++ b/tests/tooling/test_phase5_inference_smoke_metadata.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+
+from scripts.training import run_phase5_finetune as phase5
+
+
+class _FakeTensor:
+    def to(self, _device: str) -> "_FakeTensor":
+        return self
+
+
+class _FakeCuda:
+    @staticmethod
+    def is_available() -> bool:
+        return False
+
+    @staticmethod
+    def is_bf16_supported() -> bool:
+        return False
+
+
+class _FakeNoGrad:
+    def __enter__(self) -> None:
+        return None
+
+    def __exit__(self, exc_type, exc, tb) -> bool:
+        return False
+
+
+class _FakeTorch:
+    cuda = _FakeCuda()
+    float16 = "float16"
+    bfloat16 = "bfloat16"
+
+    @staticmethod
+    def no_grad() -> _FakeNoGrad:
+        return _FakeNoGrad()
+
+
+class _FakeTokenizer:
+    pad_token = "<pad>"
+    eos_token = "<eos>"
+    pad_token_id = 0
+    eos_token_id = 1
+
+    @classmethod
+    def from_pretrained(cls, _path: str, **_kwargs) -> "_FakeTokenizer":
+        return cls()
+
+    def __call__(self, _prompt: str, return_tensors: str = "pt") -> dict[str, _FakeTensor]:
+        assert return_tensors == "pt"
+        return {"input_ids": _FakeTensor(), "attention_mask": _FakeTensor()}
+
+    def decode(self, _tokens, skip_special_tokens: bool = True) -> str:
+        assert skip_special_tokens is True
+        return "When is a license required under EAR section 736.2(b)? A license may be required."
+
+
+class _FakeModel:
+    device = "cpu"
+
+    @classmethod
+    def from_pretrained(cls, _base_model: str, **_kwargs) -> "_FakeModel":
+        return cls()
+
+    def eval(self) -> None:
+        return None
+
+    def generate(self, **_kwargs):
+        return [[1, 2, 3]]
+
+
+def test_phase5_inference_smoke_includes_base_model_and_adapter_dir(
+    monkeypatch, tmp_path: Path
+) -> None:
+    adapter_dir = tmp_path / "adapter"
+    adapter_dir.mkdir(parents=True, exist_ok=True)
+
+    monkeypatch.setattr(
+        phase5,
+        "_load_training_deps",
+        lambda: (_FakeTorch, _FakeModel, _FakeTokenizer, None, None, None, None),
+    )
+    fake_peft = types.SimpleNamespace(
+        PeftModel=types.SimpleNamespace(from_pretrained=lambda model, _adapter: model)
+    )
+    monkeypatch.setitem(sys.modules, "peft", fake_peft)
+
+    result = phase5._run_inference_smoke(
+        base_model="hf-internal-testing/tiny-random-LlamaForCausalLM",
+        adapter_dir=adapter_dir,
+        prompt="When is a license required under EAR section 736.2(b)?",
+        max_new_tokens=32,
+        allow_pt_bin=False,
+    )
+
+    assert result["base_model"] == "hf-internal-testing/tiny-random-LlamaForCausalLM"
+    assert result["adapter_dir"] == str(adapter_dir)
+    assert result["pass"] is True
+

--- a/tests/tooling/test_runtime_service_surface.py
+++ b/tests/tooling/test_runtime_service_surface.py
@@ -319,6 +319,46 @@ def test_phase5_local_adapter_runtime_is_gated_and_documented() -> None:
     assert (REPO_ROOT / "scripts" / "local_adapter_smoke.ps1").exists()
 
 
+def test_phase5_local_adapter_release_evidence_contract_is_recorded() -> None:
+    readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
+    runbook = (REPO_ROOT / "RUNBOOK.md").read_text(encoding="utf-8")
+    first_pass = (REPO_ROOT / "docs" / "model_training_first_pass.md").read_text(
+        encoding="utf-8"
+    )
+    capability_doc = (
+        REPO_ROOT / "docs" / "capability_graduation_boundaries.md"
+    ).read_text(encoding="utf-8")
+    release_doc = (
+        REPO_ROOT / "docs" / "local_adapter_release_evidence.md"
+    ).read_text(encoding="utf-8")
+    release_process = (
+        REPO_ROOT / "docs" / "ops" / "release_process.md"
+    ).read_text(encoding="utf-8")
+    operator_guide = (
+        REPO_ROOT / "docs" / "ops" / "windows_single_host_operator.md"
+    ).read_text(encoding="utf-8")
+    config_record = (
+        REPO_ROOT / "config" / "local_adapter_release_evidence.example.json"
+    ).read_text(encoding="utf-8")
+
+    assert "docs/local_adapter_release_evidence.md" in readme
+    assert "docs/local_adapter_release_evidence.md" in runbook
+    assert "config/local_adapter_release_evidence.example.json" in readme
+    assert "config/local_adapter_release_evidence.example.json" in runbook
+    assert "validate_local_adapter_release_bundle" in first_pass
+    assert "docs/local_adapter_release_evidence.md" in capability_doc
+    assert "Ready for formal promotion review" in release_doc
+    assert "Keep Optional" in release_doc
+    assert "release_evidence_manifest.json" in release_doc
+    assert "validate_local_adapter_release_bundle" in release_process
+    assert "release_evidence_manifest.json" in operator_guide
+    assert '"schema_version": "local-adapter-release-evidence-contract.v1"' in config_record
+    assert '"answer_accuracy_min": 0.65' in config_record
+    assert (
+        REPO_ROOT / "scripts" / "eval" / "validate_local_adapter_release_bundle.py"
+    ).exists()
+
+
 def test_phase6_benchmark_plan_targets_the_production_candidate() -> None:
     readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
     execution_plan = (


### PR DESCRIPTION
## Summary
- complete Phase 5.2 local-adapter release evidence workflow alignment and metadata contract updates
- add Step 5.3 search/KG evidence bundle generator with dated go/no-go output
- add focused tests for release-bundle validation and search/KG evidence decision logic
- update execution/ADR/operator docs with Phase 5.2 and 5.3 status and evidence references

## Validation
- pytest -q tests/eval/test_search_kg_evidence_bundle.py tests/release/test_optional_runtime_smoke.py tests/release/test_verify_script.py
- pytest targeted suite from Phase 5.2 updates (including new inference smoke metadata test)

## Decision
- Step 5.3 recommendation: Keep Quarantined (based on current evidence bundle)
